### PR TITLE
Implement support worker booking flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,21 @@
 - Used on the Navbar (`AppBar`)
 - Applied as a global MUI theme colour when that is set up
 
+## Booking Flow — In Progress (paused 2026-04-14)
+
+### Completed
+- Backend login response now returns `user`, `client`, and `support_worker` (see `Api::SessionsController#create`)
+- `Client` model has `belongs_to :user`; `User` model has `has_one :client` and `has_one :support_worker`
+- `user_id` added to `clients` and `support_workers` tables (nullable)
+
+### Next steps
+1. Finish `AuthContext.tsx` — define `Client` (use `name` not `first_name`/`last_name`) and `SupportWorker` interfaces, add them to context type and state
+2. Update `Login.tsx` — change `response.data.success` to `response.data.user`, and also store `response.data.client` and `response.data.support_worker` in context
+3. Build `BookingForm.tsx` — modal form collecting date, duration, location, notes; `support_worker_id` passed as prop, `client_id` from `AuthContext`; submits to `POST /api/appointments`
+4. Wire `SupportWorker.js` → `BookingForm.tsx` — replace local `handleBook` with opening the form
+5. Build `AppointmentList.tsx` — page at `/appointments` using `GET /api/appointments`
+6. Add `/appointments` route in `App.tsx` and link in `Navbar`
+
 ## Architecture
 
 - Navigation is handled by a top **Navbar** (`src/components/Navbar.tsx`), not a sidebar

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -33,7 +33,6 @@ const BookingForm = ({worker, onClose, onSuccess}: BookingProps ) => {
           }
         );
         onClose();
-        console.log('onSuccess called', date)
         onSuccess(date);
         } catch (error) {
           console.error('Error posting data: ', error);

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useState } from 'react';
+import { SupportWorker } from '../context/AuthContext';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+import { Dialog, DialogTitle, DialogActions, DialogContent, TextField, Box, Button } from '@mui/material';
+
+
+interface BookingProps {
+  worker: SupportWorker;
+  onClose: () => void;
+  onSuccess: (date: string) => void;
+}
+
+const BookingForm = ({worker, onClose, onSuccess}: BookingProps ) => {
+  const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
+  const [duration, setDuration] = useState(0);
+  const [location, setLocation] = useState('');
+  const [notes, setNotes] = useState('');
+  const auth = useAuth();
+
+    const handleSubmit = async() => {
+        try {
+          const response = await axiosInstance.post('/appointments', {
+            appointment: {
+               date: date,
+               duration: duration,
+               location: location,
+               notes: notes,
+               client_id: auth.client?.id,
+               support_worker_id: worker.id
+            }
+          }
+        );
+        onClose();
+        console.log('onSuccess called', date)
+        onSuccess(date);
+        } catch (error) {
+          console.error('Error posting data: ', error);
+        }
+      };
+    return (
+      
+       <Dialog
+        open={true}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {"Book a Support Worker"}
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField 
+            label="Date"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+          <TextField 
+            label="Duration"
+            type="number"
+            value={duration}
+            onChange={(e) =>setDuration(parseInt(e.target.value))}
+            />
+          <TextField
+            label="Location"
+            value={location}
+            onChange={(e) =>setLocation(e.target.value)}
+          />
+           <TextField
+            label="Notes"
+            value={notes}
+            onChange={(e) =>setNotes(e.target.value)}
+           />
+           </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleSubmit} autoFocus>
+           Book
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  };
+
+export default BookingForm;

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -15,7 +15,9 @@ const Login = () => {
     e.preventDefault();
     try {
       const response = await axiosInstance.post('/login', { email, password });
-      auth.setUser(response.data.success);
+      auth.setUser(response.data.user);
+      auth.setClient(response.data.client);
+      auth.setSupportWorker(response.data.support_worker);
       navigate('/clients');
     } catch (error) {
       setError('Invalid email or password');

--- a/src/components/SupportWorker.js
+++ b/src/components/SupportWorker.js
@@ -63,7 +63,7 @@ const SupportWorker = ({ worker, handleBook, handleClose, isBooked }) => {
           <Box sx={{ flex: 1, pl: 2 }}>
             <Typography variant="body1"><strong>ID:</strong> {worker.id}</Typography>
             <Typography variant="body1"><strong>Location:</strong> {worker.location}</Typography>
-            <Typography variant="body1"><strong>Availability:</strong> {worker.available_days.join(', ')}</Typography>
+            <Typography variant="body1"><strong>Availability:</strong> {worker.availability}</Typography>
             <Typography variant="body1"><strong>Phone:</strong> {worker.phone}</Typography>
             <Typography variant="body1"><strong>Email:</strong> {worker.email}</Typography>
             {isBooked && (

--- a/src/components/SupportWorker.js
+++ b/src/components/SupportWorker.js
@@ -10,6 +10,8 @@ import {
   Avatar
 } from '@mui/material';
 import { styled } from '@mui/system';
+import { useState } from 'react';
+import BookingForm from './BookingForm';
 
 const CustomDialog = styled(Dialog)({
   '& .MuiDialog-paper': {
@@ -46,8 +48,11 @@ const CloseButton = styled(Button)({
   },
 });
 
-const SupportWorker = ({ worker, handleBook, handleClose, isBooked }) => {
+const SupportWorker = ({ worker, handleBook, handleClose, isBooked, onSuccess }) => {
+  const [showBookingForm, setShowBookingForm] = useState(false);
+
   return (
+    <>
     <CustomDialog open onClose={handleClose}>
       <HeaderBox>
         <Typography variant="h6">Support Worker</Typography>
@@ -79,12 +84,20 @@ const SupportWorker = ({ worker, handleBook, handleClose, isBooked }) => {
           Close
         </CloseButton>
         {!isBooked && (
-          <Button onClick={() => handleBook(worker.id)} color="primary" variant="contained" sx={{ backgroundColor: '#007bff', color: '#fff' }}>
+          <Button onClick={() => setShowBookingForm(true)} color="primary" variant="contained" sx={{ backgroundColor: '#007bff', color: '#fff' }}>
             Book
           </Button>
         )}
       </DialogActions>
-    </CustomDialog>
+      </CustomDialog>
+        {showBookingForm && (
+          <BookingForm 
+            worker={worker}
+            onSuccess={onSuccess} 
+            onClose={() => setShowBookingForm(false)} 
+          />
+        )}
+    </>
   );
 };
 

--- a/src/components/SupportWorkerList.js
+++ b/src/components/SupportWorkerList.js
@@ -12,7 +12,8 @@ import {
   Container,
   Box,
   Avatar,
-  Button
+  Button,
+  Snackbar
 } from '@mui/material';
 import SupportWorker from './SupportWorker';
 import axiosInstance from '../api/axiosConfig';
@@ -21,6 +22,7 @@ const SupportWorkerTable = () => {
   const [workers, setWorkers] = useState([]);
   const [selectedWorker, setSelectedWorker] = useState(null);
   const [bookedWorkers, setBookedWorkers] = useState(new Set());
+  const [visibleMessage, setVisibleMessage] = useState('')
 
   useEffect(() => {
     const fetchData = async () => {
@@ -100,11 +102,25 @@ const SupportWorkerTable = () => {
           worker={selectedWorker}
           handleBook={handleBook}
           handleClose={handleCloseModal}
+          onSuccess={(date) => { 
+            setVisibleMessage(`${selectedWorker.first_name} ${selectedWorker.last_name} booked for ${date}`); 
+            handleCloseModal(); 
+          }}
           isBooked={bookedWorkers.has(selectedWorker.id)}
         />
-      )}
-    </Container>
-  );
+        )
+      }
+      {visibleMessage && (
+        <Snackbar
+          open={true}
+          message={visibleMessage}
+          onClose={() => setVisibleMessage(false)}
+          autoHideDuration={5000}
+        />
+        )
+      }
+      </Container>
+    );
 };
 
 export default SupportWorkerTable;

--- a/src/components/SupportWorkerList.js
+++ b/src/components/SupportWorkerList.js
@@ -100,7 +100,7 @@ const SupportWorkerTable = () => {
           worker={selectedWorker}
           handleBook={handleBook}
           handleClose={handleCloseModal}
-          isBooked={bookedWorkers.includes(selectedWorker.id)}
+          isBooked={bookedWorkers.has(selectedWorker.id)}
         />
       )}
     </Container>

--- a/src/components/SupportWorkerList.js
+++ b/src/components/SupportWorkerList.js
@@ -21,7 +21,6 @@ import axiosInstance from '../api/axiosConfig';
 const SupportWorkerTable = () => {
   const [workers, setWorkers] = useState([]);
   const [selectedWorker, setSelectedWorker] = useState(null);
-  const [bookedWorkers, setBookedWorkers] = useState(new Set());
   const [visibleMessage, setVisibleMessage] = useState('')
 
   useEffect(() => {
@@ -37,9 +36,6 @@ const SupportWorkerTable = () => {
     fetchData();
   }, []);
 
-  const handleBook = (workerId) => {
-    setBookedWorkers((prev) => new Set([...prev, workerId]));
-  };
 
   const handleOpenModal = (worker) => {
     setSelectedWorker(worker);
@@ -100,13 +96,11 @@ const SupportWorkerTable = () => {
       {selectedWorker && (
         <SupportWorker
           worker={selectedWorker}
-          handleBook={handleBook}
           handleClose={handleCloseModal}
           onSuccess={(date) => { 
             setVisibleMessage(`${selectedWorker.first_name} ${selectedWorker.last_name} booked for ${date}`); 
             handleCloseModal(); 
           }}
-          isBooked={bookedWorkers.has(selectedWorker.id)}
         />
         )
       }
@@ -114,7 +108,7 @@ const SupportWorkerTable = () => {
         <Snackbar
           open={true}
           message={visibleMessage}
-          onClose={() => setVisibleMessage(false)}
+          onClose={() => setVisibleMessage('')}
           autoHideDuration={5000}
         />
         )

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -26,7 +26,7 @@ interface Client {
   phone: string;
 }
 
-interface SupportWorker {
+export interface SupportWorker {
   id: number;
   first_name: string;
   middle_name:  string | null;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -10,6 +10,37 @@ interface User {
   role: string | null;
 }
 
+interface Client {
+  id: number;
+  first_name: string;
+  last_name: string;
+  middle_name: string | null;
+  age: number;
+  allergies: string;
+  emergency_contact_name: string;
+  emergency_contact_phone: string;
+  address: string;
+  gender: string;
+  health_conditions: string;
+  medication: string;
+  phone: string;
+}
+
+interface SupportWorker {
+  id: number;
+  first_name: string;
+  middle_name:  string | null;
+  last_name: string;
+  age: number;
+  availability: string; 
+  bio: string;
+  email: string;
+  experience: string;
+  location: string;
+  gender: string;
+  phone: string;
+}
+
 interface AuthProviderProps {
   children: ReactNode;
 }
@@ -17,14 +48,20 @@ interface AuthProviderProps {
 interface AuthContextType {
   user: User | null;
   setUser: (user: User | null) => void;
+  client: Client | null;
+  setClient: (client: Client | null) => void;
+  supportWorker: SupportWorker | null;
+  setSupportWorker: (supportWorker: SupportWorker| null) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
+  const [client, setClient] = useState<Client | null>(null);
+  const [supportWorker, setSupportWorker] = useState<SupportWorker | null>(null);
   return (
-    <AuthContext.Provider value={{ user, setUser }}>
+    <AuthContext.Provider value={{ user, setUser, client, setClient, supportWorker, setSupportWorker }}>
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
## Summary
- Add `BookingForm.tsx` modal with date, duration, location and notes fields that submits to `POST /api/appointments`
- Wire booking form into `SupportWorker` modal — clicking Book opens the form with `support_worker_id` pre-filled
- Pass `client_id` from `AuthContext` (set on login via `user.client`)
- Show snackbar confirmation on `SupportWorkerList` page after successful booking
- Update `AuthContext` with `Client` and `SupportWorker` interfaces and state, populated on login

## Test plan
- [ ] Log in as a user linked to a client record
- [ ] Navigate to Support Workers
- [ ] Click Book on a worker — confirm `BookingForm` opens
- [ ] Fill in date, duration, location, notes and click Book
- [ ] Confirm both modals close and snackbar shows worker name and date
- [ ] Check Rails console — `Appointment.last` should have correct `client_id`, `support_worker_id` and fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)