### PR TITLE
Remove unused isBooked prop, export Client interface

### DIFF
--- a/src/components/SupportWorker.js
+++ b/src/components/SupportWorker.js
@@ -48,7 +48,7 @@ const CloseButton = styled(Button)({
   },
 });
 
-const SupportWorker = ({ worker, handleBook, handleClose, isBooked, onSuccess }) => {
+const SupportWorker = ({ worker, handleBook, handleClose, onSuccess }) => {
   const [showBookingForm, setShowBookingForm] = useState(false);
 
   return (

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -10,7 +10,7 @@ interface User {
   role: string | null;
 }
 
-interface Client {
+export interface Client {
   id: number;
   first_name: string;
   last_name: string;


### PR DESCRIPTION
## Summary
- Remove unused `isBooked` prop from `SupportWorker` component (booking is now handled by `BookingForm`)
- Export `Client` interface from `AuthContext.tsx` for reuse in other components

🤖 Generated with [Claude Code](https://claude.com/claude-code)