### PR TITLE
Add multi-step signup flow with role selection

### DIFF
--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Box, Button, TextField, Typography, Alert, Card, Select, MenuItem, FormControl, InputLabel } from '@mui/material';
 import { PersonPin, Work } from '@mui/icons-material';
 import axiosInstance from '../api/axiosConfig';
-
+import { useAuth } from '../context/AuthContext';
 const SignUp = () => {
 const [userFormData, setUserFormData] = useState({
   email: '', password: '', first_name: '', last_name: '', middle_name: ''
@@ -22,6 +23,8 @@ const [profileData, setProfileData] = useState({
   const [role, setRole] = useState('');
 
   const hasFetchcsrf = useRef(false);
+  const navigate = useNavigate();
+  const auth = useAuth();
 
   useEffect(() => {
     if (!hasFetchcsrf.current) {
@@ -61,6 +64,15 @@ const [profileData, setProfileData] = useState({
       });
       setSuccess(true);
       setErrors([]);
+      const loginResponse = await axiosInstance.post('/login', {
+        email: userFormData.email,
+        password: userFormData.password,
+      }, { withCredentials: true });
+
+      auth.setUser(loginResponse.data.user);
+      auth.setClient(loginResponse.data.client);
+      auth.setSupportWorker(loginResponse.data.support_worker);
+      navigate('/');
     } catch (err: any) {
       const errorData = err.response.data.errors;
       setErrors(Array.isArray(errorData) ? errorData : [errorData || 'An error occurred']);

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -1,56 +1,69 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Box, Button, TextField, Typography, Alert } from '@mui/material';
+import { Box, Button, TextField, Typography, Alert, Card, Select, MenuItem, FormControl, InputLabel } from '@mui/material';
+import { PersonPin, Work } from '@mui/icons-material';
 import axiosInstance from '../api/axiosConfig';
 
-
 const SignUp = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [middleName, setMiddleName] = useState('');
+const [userFormData, setUserFormData] = useState({
+  email: '', password: '', first_name: '', last_name: '', middle_name: ''
+});
+
+const [profileData, setProfileData] = useState({
+  age: '', gender: '', phone: '', location: '', bio: '',
+  experience: '', availability: '', health_conditions: '', medication: '',
+  allergies: '', emergency_contact_first_name: '', emergency_contact_last_name: '',
+  emergency_contact_phone: ''
+});
+
   const [errors, setErrors] = useState<string[]>([]);
   const [success, setSuccess] = useState(false);
-  const [csrfToken, setCsrfToken] = useState(''); 
+  const [csrfToken, setCsrfToken] = useState('');
+  const [step, setStep] = useState(1);
+  const [role, setRole] = useState('');
 
-  const hasFetchcsrf = useRef(false)
+  const hasFetchcsrf = useRef(false);
 
-  useEffect( () => {
-    if (!hasFetchcsrf.current)
-{    const fetchcsrf = async () => {
-    try{
-      const response = await axiosInstance.get('/csrf_token')
-      setCsrfToken(response.data.csrf_token);
-      hasFetchcsrf.current = true
-    } catch(error) {
+  useEffect(() => {
+    if (!hasFetchcsrf.current) {
+      const fetchcsrf = async () => {
+        try {
+          const response = await axiosInstance.get('/csrf_token');
+          setCsrfToken(response.data.csrf_token);
+          hasFetchcsrf.current = true;
+        } catch (error) {}
+      };
+      fetchcsrf();
     }
-  }
-  fetchcsrf()}
-}
-  , []);
+  }, []);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    const profilePayload = role === 'client'
+  ? { age: profileData.age, gender: profileData.gender, phone: profileData.phone, location: profileData.location, bio: profileData.bio, health_conditions: profileData.health_conditions, medication: profileData.medication, allergies: profileData.allergies, emergency_contact_first_name: profileData.emergency_contact_first_name, emergency_contact_last_name: profileData.emergency_contact_last_name, emergency_contact_phone: profileData.emergency_contact_phone }
+  : { age: profileData.age, gender: profileData.gender, phone: profileData.phone, location: profileData.location, bio: profileData.bio, experience: profileData.experience, availability: profileData.availability, emergency_contact_first_name: profileData.emergency_contact_first_name, emergency_contact_last_name: profileData.emergency_contact_last_name, emergency_contact_phone: profileData.emergency_contact_phone };
     try {
-      const response = await axiosInstance.post('/users', {
-        user: {
-        email,
-        password,
-        first_name: firstName,
-        last_name: lastName,
-        middle_name: middleName
-      }
+      await axiosInstance.post('/users', {
+        user: { ...userFormData },
+        role: role,
+        [role]: { 
+          ...profilePayload, 
+          first_name: userFormData.first_name,
+          last_name: userFormData.last_name,
+          middle_name: userFormData.middle_name,
+          email: userFormData.email
+        }
       }, {
         headers: {
           'X-CSRF-Token': csrfToken,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        withCredentials: true
+        withCredentials: true,
       });
       setSuccess(true);
       setErrors([]);
     } catch (err: any) {
-      setErrors(err.response.data.errors || ['An error occurred']);
+      const errorData = err.response.data.errors;
+      setErrors(Array.isArray(errorData) ? errorData : [errorData || 'An error occurred']);
       setSuccess(false);
     }
   };
@@ -66,29 +79,126 @@ const SignUp = () => {
         </Typography>
         {errors.length > 0 &&
           errors.map((msg) => (
-          <Alert severity="error" sx={{ mb: 3 }} key={msg}>
-            {msg}
-          </Alert>
+            <Alert severity="error" sx={{ mb: 3 }} key={msg}>
+              {msg}
+            </Alert>
           ))
         }
         {success && <Alert severity="success" sx={{ mb: 3 }}>Account created successfully!</Alert>}
-        <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={3}>
-          <TextField label="First Name" value={firstName} onChange={(e) => setFirstName(e.target.value)} fullWidth />
-          <TextField label="Middle Name" value={middleName} onChange={(e) => setMiddleName(e.target.value)} fullWidth />
-          <TextField label="Last Name" value={lastName} onChange={(e) => setLastName(e.target.value)} fullWidth />
-          <TextField label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} fullWidth />
-          <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} fullWidth />
-          <Button
-            type="submit"
-            variant="contained"
-            fullWidth
-            sx={{ backgroundColor: '#7B2FBE', py: 1.5, '&:hover': { backgroundColor: '#6a0dad' } }}
-          >
-            Sign Up
-          </Button>
-        </Box>
+
+        {step === 1 && (
+          <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={3}>
+            <TextField label="First Name" value={userFormData.first_name} onChange={(e) => setUserFormData({ ...userFormData, first_name: e.target.value })} fullWidth />
+            <TextField label="Middle Name" value={userFormData.middle_name} onChange={(e) => setUserFormData({ ...userFormData, middle_name: e.target.value })} fullWidth />
+            <TextField label="Last Name" value={userFormData.last_name} onChange={(e) => setUserFormData({ ...userFormData, last_name: e.target.value })} fullWidth />
+            <TextField label="Email" type="email" value={userFormData.email} onChange={(e) => setUserFormData({ ...userFormData, email: e.target.value })} fullWidth />
+            <TextField label="Password" type="password" value={userFormData.password}  onChange={(e) => setUserFormData({ ...userFormData, password: e.target.value })} fullWidth />
+            <Button
+              type="button"
+              onClick={() => setStep(2)}
+              variant="contained"
+              fullWidth
+              sx={{ backgroundColor: '#7B2FBE', py: 1.5, '&:hover': { backgroundColor: '#6a0dad' } }}
+            >
+              Next
+            </Button>
+          </Box>
+        )}
+        {step === 2 && (
+          <Box display="flex" gap={3} justifyContent="center" mt={3}>
+            <Card
+              onClick={() => { setRole('client'); setStep(3); }}
+              sx={{ width: 200, p: 3, cursor: 'pointer', textAlign: 'center', border: role === 'client' ? '2px solid #7B2FBE' : '2px solid transparent' }}
+            >
+              <PersonPin sx={{ fontSize: 60, color: '#7B2FBE' }} />
+              <Typography variant="h6">Client</Typography>
+            </Card>
+            <Card
+              onClick={() => { setRole('support_worker'); setStep(3); }}
+              sx={{ width: 200, p: 3, cursor: 'pointer', textAlign: 'center', border: role === 'support_worker' ? '2px solid #7B2FBE' : '2px solid transparent' }}
+            >
+              <Work sx={{ fontSize: 60, color: '#7B2FBE' }} />
+              <Typography variant="h6">Support Worker</Typography>
+            </Card>
+          </Box>
+        )}
+
+        {step === 3 && (
+          <Box display="flex" flexDirection="column" gap={3} mt={3}>
+          {role === 'client' && (
+            <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={3}>
+              <TextField label="Age" type="number" value={profileData.age} onChange={(e) => setProfileData({ ...profileData, age: e.target.value })} fullWidth />
+              <FormControl fullWidth>
+  <InputLabel>Gender</InputLabel>
+  <Select
+    value={profileData.gender}
+    label="Gender"
+    onChange={(e) => setProfileData({ ...profileData, gender: e.target.value })}
+  >
+    <MenuItem value="Male">Male</MenuItem>
+    <MenuItem value="Female">Female</MenuItem>
+    <MenuItem value="Non-binary">Non-binary</MenuItem>
+    <MenuItem value="Prefer not to say">Prefer not to say</MenuItem>
+  </Select>
+</FormControl>
+              <TextField label="Phone" value={profileData.phone} onChange={(e) => setProfileData({ ...profileData, phone: e.target.value })} fullWidth />
+              <TextField label="Location" value={profileData.location} onChange={(e) => setProfileData({ ...profileData, location: e.target.value })} fullWidth />
+              <TextField label="Bio" multiline rows={3} value={profileData.bio} onChange={(e) => setProfileData({ ...profileData, bio: e.target.value })} fullWidth />
+              <TextField label="Health Conditions" value={profileData.health_conditions} onChange={(e) => setProfileData({ ...profileData, health_conditions: e.target.value })} fullWidth />
+              <TextField label="Medication" value={profileData.medication} onChange={(e) => setProfileData({ ...profileData, medication: e.target.value })} fullWidth />
+              <TextField label="Allergies" value={profileData.allergies} onChange={(e) => setProfileData({ ...profileData, allergies: e.target.value })} fullWidth />
+              <TextField label="Emergency Contact First Name" value={profileData.emergency_contact_first_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_first_name: e.target.value })} fullWidth />
+              <TextField label="Emergency Contact Last Name" value={profileData.emergency_contact_last_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_last_name: e.target.value })} fullWidth />
+              <TextField label="Emergency Contact Phone" value={profileData.emergency_contact_phone} onChange={(e) => setProfileData({ ...profileData, emergency_contact_phone: e.target.value })} fullWidth />
+              <Button
+                type="submit"
+                variant="contained"
+                fullWidth
+                sx={{ backgroundColor: '#7B2FBE', py: 1.5, '&:hover': { backgroundColor: '#6a0dad' } }}
+              >
+                Sign Up
+              </Button>
+            </Box>
+          )}
+          {role === 'support_worker' && (
+            <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={3}>
+              <TextField label="Age" type="number" value={profileData.age} onChange={(e) => setProfileData({ ...profileData, age: e.target.value })} fullWidth />
+              <FormControl fullWidth>
+  <InputLabel>Gender</InputLabel>
+  <Select
+    value={profileData.gender}
+    label="Gender"
+    onChange={(e) => setProfileData({ ...profileData, gender: e.target.value })}
+  >
+    <MenuItem value="Male">Male</MenuItem>
+    <MenuItem value="Female">Female</MenuItem>
+    <MenuItem value="Non-binary">Non-binary</MenuItem>
+    <MenuItem value="Prefer not to say">Prefer not to say</MenuItem>
+  </Select>
+</FormControl>
+              <TextField label="Phone" value={profileData.phone} onChange={(e) => setProfileData({ ...profileData, phone: e.target.value })} fullWidth />
+              <TextField label="Location" value={profileData.location} onChange={(e) => setProfileData({ ...profileData, location: e.target.value })} fullWidth />
+              <TextField label="Bio" multiline rows={3} value={profileData.bio} onChange={(e) => setProfileData({ ...profileData, bio: e.target.value })} fullWidth />
+              <TextField label="Experience" multiline rows={3} value={profileData.experience} onChange={(e) => setProfileData({ ...profileData, experience: e.target.value })} fullWidth />
+              <TextField label="Availability" value={profileData.availability} onChange={(e) => setProfileData({ ...profileData, availability: e.target.value })} fullWidth />
+              <TextField label="Emergency Contact First Name" value={profileData.emergency_contact_first_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_first_name: e.target.value })} fullWidth />
+              <TextField label="Emergency Contact Last Name" value={profileData.emergency_contact_last_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_last_name: e.target.value })} fullWidth />
+              <TextField label="Emergency Contact Phone" value={profileData.emergency_contact_phone} onChange={(e) => setProfileData({ ...profileData, emergency_contact_phone: e.target.value })} fullWidth />
+              <Button
+                type="submit"
+                variant="contained"
+                fullWidth
+                sx={{ backgroundColor: '#7B2FBE', py: 1.5, '&:hover': { backgroundColor: '#6a0dad' } }}
+              >
+                Sign Up
+              </Button>
+            </Box>
+          )}
+          </Box>
+        )}
       </Box>
     </Box>
   );
-}
+};
+
 export default SignUp;


### PR DESCRIPTION
## Summary
- Convert SignUp to a 3-step form: account details → role selection → profile details
- Role selection cards (Client / Support Worker) with icons
- Gender dropdown with Male, Female, Non-binary, Prefer not to say options
- Auto-login and redirect to home after successful signup

## Test plan
- [ ] Sign up as a client — verify client record created and logged in
- [ ] Sign up as a support worker — verify support worker record created and logged in
- [ ] Verify duplicate email shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)