### PR TITLE
Add client list with booking flow for support workers

### DIFF
--- a/src/components/BookingForm.test.tsx
+++ b/src/components/BookingForm.test.tsx
@@ -4,39 +4,22 @@ import { waitFor } from '@testing-library/react';
 import BookingForm from './BookingForm';
 import axiosInstance from '../api/axiosConfig';
 
-const mockWorker = {
-  id: 1,
-  first_name: 'John',
-  last_name: 'Smith',
-  middle_name: null,
-  age: 30,
-  availability: 'Weekdays',
-  bio: 'Test bio',
-  email: 'john@test.com',
-  experience: '5 years',
-  location: 'Melbourne',
-  gender: 'Male',
-  phone: '0400000000'
-};
-
 jest.mock('../api/axiosConfig');
 const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
-
-jest.mock('../context/AuthContext', () => ({
-...jest.requireActual('../context/AuthContext'),
-  useAuth: () => ({ client: { id: 1 } })
-}));
 
 describe('BookingForm', () => {
   const mockOnClose = jest.fn();
   const mockOnSuccess = jest.fn();
+
   beforeEach(() => {
-    render(<BookingForm worker={mockWorker} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
-    mockedAxios.post.mockResolvedValue({ data: {}});
-  })
-  afterEach(() => { jest.clearAllMocks(); })
+    render(<BookingForm clientId={1} supportWorkerId={1} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+    mockedAxios.post.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => { jest.clearAllMocks(); });
+
   it('renders the title', () => {
-    expect(screen.getByText(/Book a Support Worker/i)).toBeInTheDocument();
+    expect(screen.getByText(/Book Appointment/i)).toBeInTheDocument();
   });
 
   it('renders the date field', () => {
@@ -58,31 +41,29 @@ describe('BookingForm', () => {
   it('renders the Book button', () => {
     expect(screen.getByRole('button', { name: /Book/i })).toBeInTheDocument();
   });
+
   it('submits the form with the correct data', async () => {
-  userEvent.type(screen.getByLabelText(/Duration/i), '30');
-  userEvent.type(screen.getByLabelText(/Location/i), 'Melbourne');
-  userEvent.type(screen.getByLabelText(/Notes/i), 'Some test notes');
-  userEvent.click(screen.getByRole('button', { name: /Book/i }));
-  await waitFor(() => {
-  expect(mockedAxios.post).toHaveBeenCalledWith('/appointments', {
-    appointment: {
-      date: expect.any(String),
-      duration: 30,
-      location: 'Melbourne',
-      notes: 'Some test notes',
-      client_id: 1,
-      support_worker_id: 1
-    }
-  });
-  });
-  })
-  it('closes the modal after submission', async () => {
+    userEvent.type(screen.getByLabelText(/Duration/i), '30');
+    userEvent.type(screen.getByLabelText(/Location/i), 'Melbourne');
+    userEvent.type(screen.getByLabelText(/Notes/i), 'Some test notes');
     userEvent.click(screen.getByRole('button', { name: /Book/i }));
     await waitFor(() => {
-      expect(mockOnSuccess).toHaveBeenCalled();
+      expect(mockedAxios.post).toHaveBeenCalledWith('/appointments', {
+        appointment: {
+          date: expect.any(String),
+          duration: 30,
+          location: 'Melbourne',
+          notes: 'Some test notes',
+          client_id: 1,
+          support_worker_id: 1,
+        }
+      });
     });
-    await waitFor(() => {
-      expect(mockOnClose).toHaveBeenCalled();
-    });
-  })
-})
+  });
+
+  it('closes the modal after submission', async () => {
+    userEvent.click(screen.getByRole('button', { name: /Book/i }));
+    await waitFor(() => { expect(mockOnSuccess).toHaveBeenCalled(); });
+    await waitFor(() => { expect(mockOnClose).toHaveBeenCalled(); });
+  });
+});

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -1,86 +1,73 @@
-import React from 'react';
 import { useState } from 'react';
-import { SupportWorker } from '../context/AuthContext';
 import axiosInstance from '../api/axiosConfig';
-import { useAuth } from '../context/AuthContext';
 import { Dialog, DialogTitle, DialogActions, DialogContent, TextField, Box, Button } from '@mui/material';
 
-
 interface BookingProps {
-  worker: SupportWorker;
+  clientId: number;
+  supportWorkerId: number;
   onClose: () => void;
   onSuccess: (date: string) => void;
 }
 
-const BookingForm = ({worker, onClose, onSuccess}: BookingProps ) => {
+const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess }: BookingProps) => {
   const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
   const [duration, setDuration] = useState(0);
   const [location, setLocation] = useState('');
   const [notes, setNotes] = useState('');
-  const auth = useAuth();
 
-    const handleSubmit = async() => {
-        try {
-          const response = await axiosInstance.post('/appointments', {
-            appointment: {
-               date: date,
-               duration: duration,
-               location: location,
-               notes: notes,
-               client_id: auth.client?.id,
-               support_worker_id: worker.id
-            }
-          }
-        );
-        onClose();
-        onSuccess(date);
-        } catch (error) {
-          console.error('Error posting data: ', error);
+  const handleSubmit = async () => {
+    try {
+      await axiosInstance.post('/appointments', {
+        appointment: {
+          date,
+          duration,
+          location,
+          notes,
+          client_id: clientId,
+          support_worker_id: supportWorkerId,
         }
-      };
-    return (
-      
-       <Dialog
-        open={true}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id="alert-dialog-title">
-          {"Book a Support Worker"}
-        </DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField 
+      });
+      onClose();
+      onSuccess(date);
+    } catch (error) {
+      console.error('Error posting data: ', error);
+    }
+  };
+
+  return (
+    <Dialog open={true} aria-labelledby="booking-dialog-title">
+      <DialogTitle id="booking-dialog-title">Book Appointment</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
             label="Date"
             type="date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
-          <TextField 
+          <TextField
             label="Duration"
             type="number"
             value={duration}
-            onChange={(e) =>setDuration(parseInt(e.target.value))}
-            />
+            onChange={(e) => setDuration(parseInt(e.target.value))}
+          />
           <TextField
             label="Location"
             value={location}
-            onChange={(e) =>setLocation(e.target.value)}
+            onChange={(e) => setLocation(e.target.value)}
           />
-           <TextField
+          <TextField
             label="Notes"
             value={notes}
-            onChange={(e) =>setNotes(e.target.value)}
-           />
-           </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleSubmit} autoFocus>
-           Book
-          </Button>
-        </DialogActions>
-      </Dialog>
-    )
-  };
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSubmit} autoFocus>Book</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
 
 export default BookingForm;

--- a/src/components/ClientList.tsx
+++ b/src/components/ClientList.tsx
@@ -1,10 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import axiosInstance from '../api/axiosConfig'; // Keep the existing axios configuration for other requests
+import { useState, useEffect } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+  Container,
+  Box,
+  Avatar,
+  Button,
+  Snackbar,
+} from '@mui/material';
+import ClientProfile from './ClientProfile';
+import axiosInstance from '../api/axiosConfig';
 import { Client } from '../context/AuthContext';
+import { useAuth } from '../context/AuthContext';
 
 const ClientList = () => {
   const [clients, setClients] = useState<Client[]>([]);
+  const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+  const [visibleMessage, setVisibleMessage] = useState('');
+  const { supportWorker } = useAuth();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -15,31 +34,72 @@ const ClientList = () => {
         console.error('Error fetching data: ', error);
       }
     };
-
     fetchData();
   }, []);
 
   return (
-    <div className="container mt-5">
-      <h1 className="text-center mb-5">Clients</h1>
-      <div className="row">
-        {clients.map(client => (
-          <div key={client.id} className="col-sm-12 col-md-6 col-lg-3 mb-4">
-            <div className="card h-100">
-              <div className="card-body">
-                <h5 className="card-title">{client.first_name} {client.last_name}</h5>
-                <h6 className="card-subtitle mb-2 text-muted">Age: {client.age}</h6>
-                <p className="card-text"><strong>Health Conditions:</strong> {client.health_conditions}</p>
-                <p className="card-text"><strong>Medications:</strong> {client.medication}</p>
-                <p className="card-text"><strong>Allergies:</strong> {client.allergies}</p>
-                <p className="card-text"><strong>Phone:</strong> {client.phone}</p>
-                <p className="card-text"><strong>Emergency Contact:</strong> {client.emergency_contact_name} ({client.emergency_contact_phone})</p>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
+    <Container>
+      <Box mt={5}>
+        <Typography variant="h4" align="center" gutterBottom>
+          Clients
+        </Typography>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Avatar</TableCell>
+                <TableCell>Name</TableCell>
+                <TableCell>Location</TableCell>
+                <TableCell>Phone</TableCell>
+                <TableCell>Health Conditions</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {clients.map((client) => (
+                <TableRow key={client.id}>
+                  <TableCell>
+                    <Avatar>{client.first_name.charAt(0)}{client.last_name.charAt(0)}</Avatar>
+                  </TableCell>
+                  <TableCell>{client.first_name} {client.last_name}</TableCell>
+                  <TableCell>{client.location}</TableCell>
+                  <TableCell>{client.phone}</TableCell>
+                  <TableCell>{client.health_conditions}</TableCell>
+                  <TableCell>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={() => setSelectedClient(client)}
+                      style={{ borderRadius: 20 }}
+                    >
+                      {supportWorker ? 'Book' : 'View'}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+      {selectedClient && (
+        <ClientProfile
+          client={selectedClient}
+          handleClose={() => setSelectedClient(null)}
+          onSuccess={(date) => {
+            setVisibleMessage(`Appointment booked for ${selectedClient.first_name} ${selectedClient.last_name} on ${date}`);
+            setSelectedClient(null);
+          }}
+        />
+      )}
+      {visibleMessage && (
+        <Snackbar
+          open={true}
+          message={visibleMessage}
+          onClose={() => setVisibleMessage('')}
+          autoHideDuration={5000}
+        />
+      )}
+    </Container>
   );
 };
 

--- a/src/components/ClientProfile.tsx
+++ b/src/components/ClientProfile.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Avatar,
+} from '@mui/material';
+import { styled } from '@mui/system';
+import { Client, useAuth } from '../context/AuthContext';
+import BookingForm from './BookingForm';
+
+const CustomDialog = styled(Dialog)({
+  '& .MuiDialog-paper': {
+    width: '600px',
+    border: '2px solid #e0e0e0',
+    borderRadius: '10px',
+    boxShadow: '0px 3px 6px rgba(0,0,0,0.16)',
+  },
+});
+
+const HeaderBox = styled(Box)({
+  backgroundColor: '#f0f0f0',
+  borderRadius: '10px 10px 0 0',
+  textAlign: 'center',
+  padding: '16px 0',
+  position: 'relative',
+});
+
+const IntersectingAvatar = styled(Avatar)({
+  width: 128,
+  height: 128,
+  position: 'absolute',
+  top: '125%',
+  left: '15%',
+  transform: 'translate(-50%, -50%)',
+  boxShadow: '0 0 6px rgba(0,0,0,0.1)',
+});
+
+const CloseButton = styled(Button)({
+  backgroundColor: '#808080',
+  color: '#ffffff',
+  '&:hover': {
+    backgroundColor: '#ff4d4d',
+  },
+});
+
+interface ClientProfileProps {
+  client: Client;
+  handleClose: () => void;
+  onSuccess: (date: string) => void;
+}
+
+const ClientProfile = ({ client, handleClose, onSuccess }: ClientProfileProps) => {
+  const [showBookingForm, setShowBookingForm] = useState(false);
+  const { supportWorker } = useAuth();
+
+  return (
+    <>
+      <CustomDialog open onClose={handleClose}>
+        <HeaderBox>
+          <Typography variant="h6">Client</Typography>
+          <IntersectingAvatar>
+            {client.first_name.charAt(0)}{client.last_name.charAt(0)}
+          </IntersectingAvatar>
+        </HeaderBox>
+        <DialogTitle sx={{ textAlign: 'left', mt: 10 }}>
+          {`${client.first_name} ${client.last_name}`}
+        </DialogTitle>
+        <DialogContent>
+          <Box display="flex">
+            <Box sx={{ flex: 1, pl: 2 }}>
+              <Typography variant="body1"><strong>Location:</strong> {client.location}</Typography>
+              <Typography variant="body1"><strong>Phone:</strong> {client.phone}</Typography>
+              <Typography variant="body1"><strong>Health Conditions:</strong> {client.health_conditions}</Typography>
+              <Typography variant="body1"><strong>Medication:</strong> {client.medication}</Typography>
+              <Typography variant="body1"><strong>Allergies:</strong> {client.allergies}</Typography>
+              <Typography variant="body1"><strong>Emergency Contact:</strong> {client.emergency_contact_first_name} {client.emergency_contact_last_name} ({client.emergency_contact_phone})</Typography>
+            </Box>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <CloseButton onClick={handleClose} variant="contained">Close</CloseButton>
+          {supportWorker && (
+            <Button onClick={() => setShowBookingForm(true)} color="primary" variant="contained" sx={{ backgroundColor: '#007bff', color: '#fff' }}>
+              Book
+            </Button>
+          )}
+        </DialogActions>
+      </CustomDialog>
+      {showBookingForm && supportWorker && (
+        <BookingForm
+          clientId={client.id}
+          supportWorkerId={supportWorker.id}
+          onSuccess={onSuccess}
+          onClose={() => setShowBookingForm(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default ClientProfile;

--- a/src/components/SupportWorker.tsx
+++ b/src/components/SupportWorker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Typography,
@@ -93,11 +92,12 @@ const SupportWorker = ({ worker, handleClose, onSuccess}: SupportWorkerProps) =>
           )}
       </DialogActions>
       </CustomDialog>
-        {showBookingForm && (
-          <BookingForm 
-            worker={worker}
-            onSuccess={onSuccess} 
-            onClose={() => setShowBookingForm(false)} 
+        {showBookingForm && client && (
+          <BookingForm
+            clientId={client.id}
+            supportWorkerId={worker.id}
+            onSuccess={onSuccess}
+            onClose={() => setShowBookingForm(false)}
           />
         )}
     </>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -16,14 +16,17 @@ export interface Client {
   last_name: string;
   middle_name: string | null;
   age: number;
-  allergies: string;
-  emergency_contact_name: string;
-  emergency_contact_phone: string;
-  address: string;
   gender: string;
+  phone: string;
+  location: string;
+  bio: string;
   health_conditions: string;
   medication: string;
-  phone: string;
+  allergies: string;
+  emergency_contact_first_name: string;
+  emergency_contact_last_name: string;
+  emergency_contact_phone: string;
+  email: string;
 }
 
 export interface SupportWorker {


### PR DESCRIPTION
## Summary
- Refactors `BookingForm` to accept `clientId`/`supportWorkerId` directly, making it direction-agnostic for both client→worker and worker→client bookings
- Adds `ClientProfile` modal (mirrors `SupportWorker` modal) with Book button visible to support workers only
- Upgrades `ClientList` from Bootstrap cards to MUI table with profile modal; button label toggles between "Book" (support workers) and "View" (clients)
- Fixes stale `Client` interface in `AuthContext` — corrects field names to match schema (`location`, split emergency contact fields)

## Test plan
- [ ] All 16 existing tests pass
- [ ] Client logged in: support worker list shows Book button, client list shows View button (no Book)
- [ ] Support worker logged in: client list shows Book button, support worker list shows no Book button
- [ ] Support worker can book a client through the client list modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)