### PR TITLE
Client privacy: hide Clients section from client-role users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
 import { Box, CssBaseline } from '@mui/material';
 import SecureRoute from './components/SecureRoute';
 import Home from './components/Home';
@@ -9,7 +9,13 @@ import AppointmentList from './components/AppointmentList';
 import Navbar from './components/Navbar';
 import SignUp from './components/SignUp';
 import Login from './components/Login';
-import { AuthProvider } from './context/AuthContext';
+import { AuthProvider, useAuth } from './context/AuthContext';
+
+const ClientsRoute = () => {
+  const { client } = useAuth();
+  if (client) return <Navigate to="/" replace />;
+  return <ClientList />;
+};
 
 const App = () => {
   return (
@@ -20,7 +26,7 @@ const App = () => {
         <Box component="main" sx={{ p: 3, mt: 8 }}>
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/clients" element={<SecureRoute><ClientList /></SecureRoute>} />
+            <Route path="/clients" element={<SecureRoute><ClientsRoute /></SecureRoute>} />
             <Route path='/support-workers' element={<SecureRoute><SupportWorkerList /></SecureRoute>} />
             <Route path='/appointments' element={<SecureRoute><AppointmentList /></SecureRoute>} />
             <Route path="/signup" element={<SignUp />} />

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Navbar from './Navbar';
+import { useAuth } from '../context/AuthContext';
+
+jest.mock('react-router-dom', () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+
+const mockUseAuth = useAuth as jest.Mock;
+
+describe('Navbar', () => {
+  afterEach(() => { jest.clearAllMocks(); });
+
+  it('hides the Clients link for client users', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, first_name: 'Jane' },
+      client: { id: 1, first_name: 'Jane', last_name: 'Doe' },
+      supportWorker: null,
+      setUser: jest.fn(),
+    });
+    render(<Navbar />);
+    expect(screen.queryByRole('link', { name: /clients/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the Clients link for support worker users', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, first_name: 'Bob' },
+      client: null,
+      supportWorker: { id: 1, first_name: 'Bob', last_name: 'Brown' },
+      setUser: jest.fn(),
+    });
+    render(<Navbar />);
+    expect(screen.getByRole('link', { name: /clients/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,7 @@ const handleLogout = () => {
     <AppBar sx={{ backgroundColor: '#7B2FBE', boxShadow: 'none' }}>
       <Toolbar>
         <Button color="inherit" component={Link} to="/">Home</Button>
-        <Button color="inherit" component={Link} to="/clients">Clients</Button>
+        {auth.supportWorker && <Button color="inherit" component={Link} to="/clients">Clients</Button>}
         <Button color="inherit" component={Link} to="/support-workers">Support Workers</Button>
         <Button color="inherit" component={Link} to="/appointments">Appointments</Button>
         


### PR DESCRIPTION
## Summary
- Navbar hides the Clients link when the logged-in user is a client
- `/clients` route redirects client users to home
- Adds `Navbar.test.tsx` asserting role-conditional link visibility

## Test plan
- [ ] Log in as a client — Clients link absent from nav, direct URL redirects to home
- [ ] Log in as a support worker — Clients link present and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)