### PR TITLE
Add chip/bubble selectors for medications, allergies and specializations

### DIFF
--- a/src/components/ChipSelector.test.tsx
+++ b/src/components/ChipSelector.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChipSelector from './ChipSelector';
+
+const OPTIONS = ['Option A', 'Option B', 'Option C'];
+
+describe('ChipSelector', () => {
+  it('renders the label', () => {
+    render(<ChipSelector label="Medications" options={OPTIONS} value={[]} onChange={jest.fn()} />);
+    expect(screen.getByLabelText(/medications/i)).toBeInTheDocument();
+  });
+
+  it('renders pre-selected values as chips', () => {
+    render(<ChipSelector label="Medications" options={OPTIONS} value={['Option A']} onChange={jest.fn()} />);
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+  });
+
+  it('calls onChange when a chip is removed', async () => {
+    const onChange = jest.fn();
+    render(<ChipSelector label="Medications" options={OPTIONS} value={['Option A']} onChange={onChange} />);
+    const deleteButton = screen.getByTestId('CancelIcon');
+    await userEvent.click(deleteButton);
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/ChipSelector.tsx
+++ b/src/components/ChipSelector.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Autocomplete, TextField, Chip } from '@mui/material';
+
+interface ChipSelectorProps {
+  label: string;
+  options: string[];
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+const ChipSelector = ({ label, options, value, onChange }: ChipSelectorProps) => (
+  <Autocomplete
+    multiple
+    freeSolo
+    options={options}
+    value={value}
+    onChange={(_, newValue) => onChange(newValue as string[])}
+    renderTags={(tagValue, getTagProps) =>
+      tagValue.map((option, index) => (
+        <Chip
+          label={option}
+          {...getTagProps({ index })}
+          sx={{ bgcolor: '#7B2FBE', color: 'white', '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' } }}
+        />
+      ))
+    }
+    renderInput={(params) => <TextField {...params} label={label} />}
+  />
+);
+
+export default ChipSelector;

--- a/src/components/ChipSelector.tsx
+++ b/src/components/ChipSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import { Autocomplete, TextField, Chip } from '@mui/material';
 
 interface ChipSelectorProps {
@@ -8,24 +8,33 @@ interface ChipSelectorProps {
   onChange: (value: string[]) => void;
 }
 
-const ChipSelector = ({ label, options, value, onChange }: ChipSelectorProps) => (
-  <Autocomplete
-    multiple
-    freeSolo
-    options={options}
-    value={value}
-    onChange={(_, newValue) => onChange(newValue as string[])}
-    renderTags={(tagValue, getTagProps) =>
-      tagValue.map((option, index) => (
-        <Chip
-          label={option}
-          {...getTagProps({ index })}
-          sx={{ bgcolor: '#7B2FBE', color: 'white', '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' } }}
-        />
-      ))
-    }
-    renderInput={(params) => <TextField {...params} label={label} />}
-  />
-);
+const ChipSelector = ({ label, options, value, onChange }: ChipSelectorProps) => {
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <Autocomplete
+      multiple
+      freeSolo
+      options={options}
+      value={value}
+      inputValue={inputValue}
+      open={inputValue.length > 0}
+      onInputChange={(_, newInputValue) => setInputValue(newInputValue)}
+      onChange={(_, newValue) => onChange(newValue as string[])}
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            label={option}
+            {...getTagProps({ index })}
+            sx={{ bgcolor: '#7B2FBE', color: 'white', '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' } }}
+          />
+        ))
+      }
+      renderInput={(params) => (
+        <TextField {...params} label={label} placeholder={`Search ${label.toLowerCase()}…`} />
+      )}
+    />
+  );
+};
 
 export default ChipSelector;

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -80,7 +80,7 @@ const SignUp = () => {
       auth.setSupportWorker(loginResponse.data.support_worker);
       navigate('/');
     } catch (err: any) {
-      const errorData = err.response.data.errors;
+      const errorData = err.response?.data?.errors || err.response?.data?.error;
       setErrors(Array.isArray(errorData) ? errorData : [errorData || 'An error occurred']);
       setSuccess(false);
     }

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Button, TextField, Typography, Alert, Card, Select, MenuItem, FormControl, InputLabel } from '@mui/material';
+import ChipSelector from './ChipSelector';
+import { MEDICATIONS, ALLERGIES, SPECIALIZATIONS } from '../constants/selectorOptions';
 import { PersonPin, Work } from '@mui/icons-material';
 import axiosInstance from '../api/axiosConfig';
 import { useAuth } from '../context/AuthContext';
@@ -12,10 +14,13 @@ const SignUp = () => {
 
   const [profileData, setProfileData] = useState({
     age: '', gender: '', phone: '', location: '', bio: '',
-    experience: '', availability: '', health_conditions: '', medication: '',
-    allergies: '', emergency_contact_first_name: '', emergency_contact_last_name: '',
+    experience: '', availability: '', health_conditions: '',
+    emergency_contact_first_name: '', emergency_contact_last_name: '',
     emergency_contact_phone: ''
   });
+  const [selectedMedications, setSelectedMedications] = useState<string[]>([]);
+  const [selectedAllergies, setSelectedAllergies] = useState<string[]>([]);
+  const [selectedSpecializations, setSelectedSpecializations] = useState<string[]>([]);
 
   const [errors, setErrors] = useState<string[]>([]);
   const [success, setSuccess] = useState(false);
@@ -43,8 +48,8 @@ const SignUp = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     const profilePayload = role === 'client'
-      ? { age: profileData.age, gender: profileData.gender, phone: profileData.phone, location: profileData.location, bio: profileData.bio, health_conditions: profileData.health_conditions, medication: profileData.medication, allergies: profileData.allergies, emergency_contact_first_name: profileData.emergency_contact_first_name, emergency_contact_last_name: profileData.emergency_contact_last_name, emergency_contact_phone: profileData.emergency_contact_phone }
-      : { age: profileData.age, gender: profileData.gender, phone: profileData.phone, location: profileData.location, bio: profileData.bio, experience: profileData.experience, availability: profileData.availability, emergency_contact_first_name: profileData.emergency_contact_first_name, emergency_contact_last_name: profileData.emergency_contact_last_name, emergency_contact_phone: profileData.emergency_contact_phone };
+      ? { age: profileData.age, gender: profileData.gender, phone: profileData.phone, location: profileData.location, bio: profileData.bio, health_conditions: profileData.health_conditions, medication: selectedMedications.join(', '), allergies: selectedAllergies.join(', '), emergency_contact_first_name: profileData.emergency_contact_first_name, emergency_contact_last_name: profileData.emergency_contact_last_name, emergency_contact_phone: profileData.emergency_contact_phone }
+      : { age: profileData.age, gender: profileData.gender, phone: profileData.phone, location: profileData.location, bio: profileData.bio, experience: profileData.experience, availability: profileData.availability, specializations: selectedSpecializations, emergency_contact_first_name: profileData.emergency_contact_first_name, emergency_contact_last_name: profileData.emergency_contact_last_name, emergency_contact_phone: profileData.emergency_contact_phone };
     try {
       await axiosInstance.post('/users', {
         user: { ...userFormData },
@@ -195,8 +200,8 @@ const SignUp = () => {
                 <TextField label="Location" value={profileData.location} onChange={(e) => setProfileData({ ...profileData, location: e.target.value })} fullWidth />
                 <TextField label="Bio" multiline rows={3} value={profileData.bio} onChange={(e) => setProfileData({ ...profileData, bio: e.target.value })} fullWidth />
                 <TextField label="Health Conditions" value={profileData.health_conditions} onChange={(e) => setProfileData({ ...profileData, health_conditions: e.target.value })} fullWidth />
-                <TextField label="Medication" value={profileData.medication} onChange={(e) => setProfileData({ ...profileData, medication: e.target.value })} fullWidth />
-                <TextField label="Allergies" value={profileData.allergies} onChange={(e) => setProfileData({ ...profileData, allergies: e.target.value })} fullWidth />
+                <ChipSelector label="Medication" options={MEDICATIONS} value={selectedMedications} onChange={setSelectedMedications} />
+                <ChipSelector label="Allergies" options={ALLERGIES} value={selectedAllergies} onChange={setSelectedAllergies} />
                 <TextField label="Emergency Contact First Name" value={profileData.emergency_contact_first_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_first_name: e.target.value })} fullWidth />
                 <TextField label="Emergency Contact Last Name" value={profileData.emergency_contact_last_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_last_name: e.target.value })} fullWidth />
                 <TextField label="Emergency Contact Phone" value={profileData.emergency_contact_phone} onChange={(e) => setProfileData({ ...profileData, emergency_contact_phone: e.target.value })} fullWidth />
@@ -212,6 +217,7 @@ const SignUp = () => {
                 <TextField label="Bio" multiline rows={3} value={profileData.bio} onChange={(e) => setProfileData({ ...profileData, bio: e.target.value })} fullWidth />
                 <TextField label="Experience" multiline rows={3} value={profileData.experience} onChange={(e) => setProfileData({ ...profileData, experience: e.target.value })} fullWidth />
                 <TextField label="Availability" value={profileData.availability} onChange={(e) => setProfileData({ ...profileData, availability: e.target.value })} fullWidth />
+                <ChipSelector label="Specializations" options={SPECIALIZATIONS} value={selectedSpecializations} onChange={setSelectedSpecializations} />
                 <TextField label="Emergency Contact First Name" value={profileData.emergency_contact_first_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_first_name: e.target.value })} fullWidth />
                 <TextField label="Emergency Contact Last Name" value={profileData.emergency_contact_last_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_last_name: e.target.value })} fullWidth />
                 <TextField label="Emergency Contact Phone" value={profileData.emergency_contact_phone} onChange={(e) => setProfileData({ ...profileData, emergency_contact_phone: e.target.value })} fullWidth />

--- a/src/constants/selectorOptions.ts
+++ b/src/constants/selectorOptions.ts
@@ -1,0 +1,18 @@
+export const MEDICATIONS = [
+  'Metformin', 'Lisinopril', 'Atorvastatin', 'Amlodipine', 'Omeprazole',
+  'Levothyroxine', 'Sertraline', 'Paracetamol', 'Ibuprofen', 'Aspirin',
+  'Ramipril', 'Bisoprolol', 'Warfarin', 'Furosemide', 'Salbutamol',
+];
+
+export const ALLERGIES = [
+  'Penicillin', 'Peanuts', 'Tree nuts', 'Shellfish', 'Dairy',
+  'Gluten', 'Latex', 'Bee stings', 'Aspirin', 'Sulfa drugs',
+  'Eggs', 'Soy', 'Fish', 'Ibuprofen', 'Codeine',
+];
+
+export const SPECIALIZATIONS = [
+  'Personal Care', 'Meal Preparation', 'Medication Management',
+  'Mobility Assistance', 'Community Access', 'Domestic Assistance',
+  'Respite Care', 'Behaviour Support', 'Transport', 'Social Support',
+  'Allied Health Support', 'Complex Care',
+];


### PR DESCRIPTION
## Summary
- Replaces plain text inputs in the sign-up form with MUI `Autocomplete` + `Chip` selectors
- Clients get chip selectors for Medications and Allergies
- Support workers get a chip selector for Specializations
- Supports free-text entry (type a value, press Enter) as well as preset options
- Selected chips render with the app's primary purple (`#7B2FBE`) for visual consistency

## New files
- `src/constants/selectorOptions.ts` — preset option arrays for all three selectors
- `src/components/ChipSelector.tsx` — reusable Autocomplete + Chip component

## Test plan
- [ ] Sign up as a client → Medications and Allergies show chip selectors
- [ ] Type a custom medication name and press Enter → chip appears
- [ ] Sign up as a support worker → Specializations shows chip selector with preset options
- [ ] Submit the form → joined values are sent correctly to the API (`medication: "Aspirin, Ibuprofen"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)