### PR TITLE
Add Rebook button to past appointments

### DIFF
--- a/src/components/AppointmentList.tsx
+++ b/src/components/AppointmentList.tsx
@@ -29,6 +29,7 @@ const AppointmentList = () => {
   const [appointmentToDelete, setAppointmentToDelete] = useState<Appointment | null>(null);
   const [appointmentToEdit, setAppointmentToEdit] = useState<Appointment | undefined>(undefined);
   const [editDialogueVisible, setEditDialogueVisible] = useState(false);
+  const [rebookAppointment, setRebookAppointment] = useState<Appointment | null>(null);
   const [agentOpen, setAgentOpen] = useState(false);
 
   const { client } = useAuth();
@@ -113,8 +114,14 @@ const AppointmentList = () => {
                   <TableCell>{formatDuration(appointment.duration)}</TableCell>
                   <TableCell>{appointment.notes}</TableCell>
                   <TableCell>
-                    <Button onClick={() => handleEdit(appointment)}>Edit</Button>
-                    <Button onClick={() => { setAppointmentToDelete(appointment); setDeleteDialogueVisible(true); }}>Delete</Button>
+                    {new Date(appointment.date) > new Date() ? (
+                      <>
+                        <Button onClick={() => handleEdit(appointment)}>Edit</Button>
+                        <Button onClick={() => { setAppointmentToDelete(appointment); setDeleteDialogueVisible(true); }}>Delete</Button>
+                      </>
+                    ) : (
+                      <Button onClick={() => setRebookAppointment(appointment)}>Rebook</Button>
+                    )}
                   </TableCell>
                 </TableRow>
               ))}
@@ -140,6 +147,14 @@ const AppointmentList = () => {
           supportWorkerId={appointmentToEdit.support_worker.id}
           onClose={() => setEditDialogueVisible(false)}
           onSuccess={() => setVisibleMessage('Appointment successfully updated')}
+        />
+      )}
+      {rebookAppointment && (
+        <BookingForm
+          clientId={rebookAppointment.client.id}
+          supportWorkerId={rebookAppointment.support_worker.id}
+          onClose={() => setRebookAppointment(null)}
+          onSuccess={() => { setVisibleMessage('Appointment booked'); fetchAppointments(); }}
         />
       )}
       {deleteDialogueVisible && (


### PR DESCRIPTION
## Summary
- Past appointments in AppointmentList no longer show Edit or Delete buttons
- A Rebook button appears instead, opening BookingForm pre-filled with the same client and support worker to create a fresh appointment
- After rebooking, the list refreshes automatically

## Test plan
- [ ] Navigate to Appointments as a client or support worker
- [ ] Confirm past appointments show only a Rebook button
- [ ] Confirm future appointments still show Edit and Delete
- [ ] Click Rebook on a past appointment and verify the form pre-fills correctly and creates a new appointment

🤖 Generated with [Claude Code](https://claude.com/claude-code)