### PR TITLE
Add AvailabilitySelector for support workers

### DIFF
--- a/src/components/AvailabilitySelector.tsx
+++ b/src/components/AvailabilitySelector.tsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react';
+import {
+  Box, Typography, Chip, TextField, FormControlLabel, Checkbox, ToggleButton, ToggleButtonGroup,
+} from '@mui/material';
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+const PRESETS = [
+  { label: 'Morning', value: '06:00-12:00' },
+  { label: 'Afternoon', value: '12:00-18:00' },
+  { label: 'Evening', value: '18:00-22:00' },
+  { label: 'Full Day', value: '06:00-22:00' },
+  { label: 'Custom', value: 'custom' },
+];
+
+interface AvailabilityValue {
+  days: string[];
+  time_window: string;
+}
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function parse(raw: string): AvailabilityValue {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && Array.isArray(parsed.days) && typeof parsed.time_window === 'string') {
+      return parsed;
+    }
+  } catch {}
+  return { days: [], time_window: '' };
+}
+
+function encode(days: string[], timeWindow: string): string {
+  return JSON.stringify({ days, time_window: timeWindow });
+}
+
+export function formatAvailability(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed?.days || !parsed?.time_window) return raw;
+    const days: string[] = parsed.days;
+    const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+    const weekend = ['Sat', 'Sun'];
+    let dayLabel: string;
+    if (days.length === 7) {
+      dayLabel = 'Every day';
+    } else if (weekdays.every(d => days.includes(d)) && days.length === 5) {
+      dayLabel = 'Weekdays';
+    } else if (weekend.every(d => days.includes(d)) && days.length === 2) {
+      dayLabel = 'Weekends';
+    } else {
+      dayLabel = days.join(', ');
+    }
+    const preset = PRESETS.find(p => p.value === parsed.time_window);
+    const timeLabel = preset && preset.value !== 'custom' ? `${preset.label} (${parsed.time_window})` : parsed.time_window;
+    return `${dayLabel} · ${timeLabel}`;
+  } catch {
+    return raw;
+  }
+}
+
+const AvailabilitySelector = ({ value, onChange }: Props) => {
+  const initial = parse(value);
+  const [selectedDays, setSelectedDays] = useState<string[]>(initial.days);
+  const presetMatch = PRESETS.find(p => p.value === initial.time_window);
+  const [preset, setPreset] = useState<string>(presetMatch ? initial.time_window : initial.time_window ? 'custom' : '');
+  const [customFrom, setCustomFrom] = useState(() => {
+    if (!presetMatch && initial.time_window.includes('-')) return initial.time_window.split('-')[0];
+    return '09:00';
+  });
+  const [customTo, setCustomTo] = useState(() => {
+    if (!presetMatch && initial.time_window.includes('-')) return initial.time_window.split('-')[1];
+    return '17:00';
+  });
+
+  useEffect(() => {
+    const timeWindow = preset === 'custom' ? `${customFrom}-${customTo}` : preset;
+    onChange(encode(selectedDays, timeWindow));
+  }, [selectedDays, preset, customFrom, customTo]);
+
+  const toggleDay = (day: string) => {
+    setSelectedDays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+    );
+  };
+
+  const selectWeekdays = () => setSelectedDays(['Mon', 'Tue', 'Wed', 'Thu', 'Fri']);
+  const selectWeekend = () => setSelectedDays(['Sat', 'Sun']);
+  const selectAll = () => setSelectedDays([...DAYS]);
+  const clearDays = () => setSelectedDays([]);
+
+  const daysSummary = () => {
+    if (selectedDays.length === 7) return 'Every day';
+    if (['Mon', 'Tue', 'Wed', 'Thu', 'Fri'].every(d => selectedDays.includes(d)) && selectedDays.length === 5) return 'Weekdays';
+    if (['Sat', 'Sun'].every(d => selectedDays.includes(d)) && selectedDays.length === 2) return 'Weekends';
+    return null;
+  };
+
+  const summary = daysSummary();
+
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" mb={1}>Available Days</Typography>
+      <Box display="flex" gap={0.5} flexWrap="wrap" mb={1}>
+        {DAYS.map(day => (
+          <FormControlLabel
+            key={day}
+            control={
+              <Checkbox
+                checked={selectedDays.includes(day)}
+                onChange={() => toggleDay(day)}
+                size="small"
+                sx={{ color: '#7B2FBE', '&.Mui-checked': { color: '#7B2FBE' } }}
+              />
+            }
+            label={day}
+            sx={{ mr: 0.5 }}
+          />
+        ))}
+      </Box>
+      <Box display="flex" gap={1} mb={summary ? 1 : 0}>
+        <Chip label="Weekdays" size="small" variant="outlined" onClick={selectWeekdays} sx={{ cursor: 'pointer' }} />
+        <Chip label="Weekends" size="small" variant="outlined" onClick={selectWeekend} sx={{ cursor: 'pointer' }} />
+        <Chip label="Every day" size="small" variant="outlined" onClick={selectAll} sx={{ cursor: 'pointer' }} />
+        {selectedDays.length > 0 && (
+          <Chip label="Clear" size="small" onClick={clearDays} sx={{ cursor: 'pointer' }} />
+        )}
+      </Box>
+      {summary && (
+        <Typography variant="caption" color="#7B2FBE" fontWeight={600}>{summary} selected</Typography>
+      )}
+
+      <Typography variant="body2" color="text.secondary" mt={2} mb={1}>Time Window</Typography>
+      <ToggleButtonGroup
+        value={preset}
+        exclusive
+        onChange={(_, v) => { if (v !== null) setPreset(v); }}
+        size="small"
+        sx={{ flexWrap: 'wrap', gap: 0.5 }}
+      >
+        {PRESETS.map(p => (
+          <ToggleButton
+            key={p.value}
+            value={p.value}
+            sx={{
+              borderRadius: '20px !important',
+              border: '1px solid #7B2FBE !important',
+              color: '#7B2FBE',
+              '&.Mui-selected': { bgcolor: '#7B2FBE', color: 'white' },
+              '&.Mui-selected:hover': { bgcolor: '#6a27a3' },
+              mr: 0.5,
+              mb: 0.5,
+            }}
+          >
+            {p.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+
+      {preset === 'custom' && (
+        <Box display="flex" gap={2} mt={1.5} alignItems="center">
+          <TextField
+            label="From"
+            type="time"
+            size="small"
+            value={customFrom}
+            onChange={e => setCustomFrom(e.target.value)}
+            sx={{ width: 130 }}
+          />
+          <Typography>to</Typography>
+          <TextField
+            label="To"
+            type="time"
+            size="small"
+            value={customTo}
+            onChange={e => setCustomTo(e.target.value)}
+            sx={{ width: 130 }}
+          />
+        </Box>
+      )}
+      {preset && preset !== 'custom' && (
+        <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+          {PRESETS.find(p => p.value === preset)?.label}: {preset}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default AvailabilitySelector;

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Button, TextField, Typography, Alert, Card, Select, MenuItem, FormControl, InputLabel } from '@mui/material';
 import ChipSelector from './ChipSelector';
+import AvailabilitySelector from './AvailabilitySelector';
 import { MEDICATIONS, ALLERGIES, SPECIALIZATIONS } from '../constants/selectorOptions';
 import { PersonPin, Work } from '@mui/icons-material';
 import axiosInstance from '../api/axiosConfig';
@@ -216,7 +217,7 @@ const SignUp = () => {
                 <TextField label="Location" value={profileData.location} onChange={(e) => setProfileData({ ...profileData, location: e.target.value })} fullWidth />
                 <TextField label="Bio" multiline rows={3} value={profileData.bio} onChange={(e) => setProfileData({ ...profileData, bio: e.target.value })} fullWidth />
                 <TextField label="Experience" multiline rows={3} value={profileData.experience} onChange={(e) => setProfileData({ ...profileData, experience: e.target.value })} fullWidth />
-                <TextField label="Availability" value={profileData.availability} onChange={(e) => setProfileData({ ...profileData, availability: e.target.value })} fullWidth />
+                <AvailabilitySelector value={profileData.availability} onChange={(v) => setProfileData({ ...profileData, availability: v })} />
                 <ChipSelector label="Specializations" options={SPECIALIZATIONS} value={selectedSpecializations} onChange={setSelectedSpecializations} />
                 <TextField label="Emergency Contact First Name" value={profileData.emergency_contact_first_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_first_name: e.target.value })} fullWidth />
                 <TextField label="Emergency Contact Last Name" value={profileData.emergency_contact_last_name} onChange={(e) => setProfileData({ ...profileData, emergency_contact_last_name: e.target.value })} fullWidth />

--- a/src/components/SupportWorkerProfilePage.tsx
+++ b/src/components/SupportWorkerProfilePage.tsx
@@ -8,6 +8,7 @@ import { LocationOn, Phone, Email, Work, Schedule, ArrowBack, Edit, Save, Cancel
 import axiosInstance from '../api/axiosConfig';
 import { SupportWorker } from '../context/AuthContext';
 import { useAuth } from '../context/AuthContext';
+import AvailabilitySelector, { formatAvailability } from './AvailabilitySelector';
 import BookingForm from './BookingForm';
 
 const GENDERS = ['Male', 'Female', 'Non-binary', 'Prefer not to say'];
@@ -118,9 +119,12 @@ const SupportWorkerProfilePage = () => {
               <Email sx={{ color: '#7B2FBE', fontSize: 20, flexShrink: 0 }} />
               <Typography variant="body2">{worker.email}</Typography>
             </Box>
-            <Box display="flex" alignItems="center" gap={1}>
-              <Schedule sx={{ color: '#7B2FBE', fontSize: 20, flexShrink: 0 }} />
-              {field('availability')}
+            <Box display="flex" alignItems="flex-start" gap={1}>
+              <Schedule sx={{ color: '#7B2FBE', fontSize: 20, flexShrink: 0, mt: 0.25 }} />
+              {editing
+                ? <AvailabilitySelector value={form.availability ?? ''} onChange={v => setForm({ ...form, availability: v })} />
+                : <Typography variant="body2">{formatAvailability(worker.availability) || '—'}</Typography>
+              }
             </Box>
             {editing && (
               <Box mt={2}>


### PR DESCRIPTION
## Summary
- New `AvailabilitySelector` component replaces the plain text availability field for support workers
- Day checkboxes (Mon–Sun) with quick-select shortcuts: Weekdays, Weekends, Every day
- Preset time windows: Morning (06:00–12:00), Afternoon (12:00–18:00), Evening (18:00–22:00), Full Day (06:00–22:00), Custom (free time range input)
- Value stored as JSON: `{"days": ["Mon","Tue",...], "time_window": "06:00-12:00"}`
- `formatAvailability()` renders the JSON as human-readable text on the profile view (e.g. "Weekdays · Morning (06:00–12:00)")
- Integrated into SignUp (step 3, support worker) and SupportWorkerProfilePage (edit mode)

## Test plan
- [ ] Sign up as a support worker — confirm day checkboxes and time window presets appear
- [ ] Select Weekdays shortcut — confirm Mon–Fri are all checked and "Weekdays selected" label shows
- [ ] Select Custom time window — confirm from/to inputs appear
- [ ] Save and view profile — confirm availability displays as formatted text
- [ ] Edit profile — confirm existing availability loads correctly into the selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)