### PR TITLE
Add chat messaging, AI simulation, invitations and notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import Home from './components/Home';
 import SupportWorkerList from './components/SupportWorkerList';
 import ClientList from './components/ClientList';
 import AppointmentList from './components/AppointmentList';
+import ConversationList from './components/ConversationList';
+import ConversationView from './components/ConversationView';
+import InvitationsPage from './components/InvitationsPage';
 import SupportWorkerProfilePage from './components/SupportWorkerProfilePage';
 import ClientProfilePage from './components/ClientProfilePage';
 import Navbar from './components/Navbar';
@@ -33,6 +36,9 @@ const App = () => {
             <Route path='/support-workers' element={<SecureRoute><SupportWorkerList /></SecureRoute>} />
             <Route path='/support-workers/:id' element={<SecureRoute><SupportWorkerProfilePage /></SecureRoute>} />
             <Route path='/appointments' element={<SecureRoute><AppointmentList /></SecureRoute>} />
+            <Route path='/invitations' element={<SecureRoute><InvitationsPage /></SecureRoute>} />
+            <Route path='/messages' element={<SecureRoute><ConversationList /></SecureRoute>} />
+            <Route path='/messages/:id' element={<SecureRoute><ConversationView /></SecureRoute>} />
             <Route path="/signup" element={<SignUp />} />
             <Route path="/login" element={<Login />} />
           </Routes>

--- a/src/components/AppointmentList.tsx
+++ b/src/components/AppointmentList.tsx
@@ -136,7 +136,7 @@ const AppointmentList = () => {
         <BookingAgent
           open={agentOpen}
           onClose={() => setAgentOpen(false)}
-          onBooked={() => { setAgentOpen(false); fetchAppointments(); }}
+          onBooked={(convId) => { setAgentOpen(false); navigate(`/messages/${convId}`); }}
           isClient={isClient}
         />
       )}

--- a/src/components/AppointmentList.tsx
+++ b/src/components/AppointmentList.tsx
@@ -106,8 +106,8 @@ const AppointmentList = () => {
                     sx={{ cursor: 'pointer', color: '#7B2FBE', fontWeight: 600, '&:hover': { textDecoration: 'underline' } }}
                   >
                     {isClient
-                      ? `${appointment.support_worker.first_name} ${appointment.support_worker.last_name}`
-                      : `${appointment.client.first_name} ${appointment.client.last_name}`
+                      ? `${appointment.support_worker?.first_name ?? ''} ${appointment.support_worker?.last_name ?? ''}`.trim() || '—'
+                      : `${appointment.client?.first_name ?? ''} ${appointment.client?.last_name ?? ''}`.trim() || '—'
                     }
                   </TableCell>
                   <TableCell>{appointment.location}</TableCell>

--- a/src/components/BookingAgent.tsx
+++ b/src/components/BookingAgent.tsx
@@ -20,7 +20,7 @@ interface Message {
 interface BookingAgentProps {
   open: boolean;
   onClose: () => void;
-  onBooked: () => void;
+  onBooked: (conversationId: number) => void;
   isClient?: boolean;
 }
 
@@ -28,8 +28,8 @@ const BookingAgent = ({ open, onClose, onBooked, isClient = true }: BookingAgent
   const welcome: Message = {
     role: 'assistant',
     content: isClient
-      ? "Hi! I'm your AI booking assistant. Tell me what kind of support you're looking for and I'll find the right worker for you."
-      : "Hi! I'm your AI booking assistant. Tell me what kind of client you're looking to support and I'll help you find a match.",
+      ? "Hi! I'm your AI booking assistant. Tell me what kind of support you're looking for and I'll find the right worker and send them an invitation on your behalf."
+      : "Hi! I'm your AI booking assistant. Tell me which client you'd like to book with and I'll send them an appointment invitation.",
   };
   const [messages, setMessages] = useState<Message[]>([welcome]);
   const [input, setInput] = useState('');
@@ -54,8 +54,8 @@ const BookingAgent = ({ open, onClose, onBooked, isClient = true }: BookingAgent
       const { data } = await axiosInstance.post('/ai_booking/chat', { messages: next, timezone });
       const reply = data.message as string;
       setMessages([...next, { role: 'assistant', content: reply }]);
-      if (reply.toLowerCase().includes('confirmed') || reply.toLowerCase().includes('booked')) {
-        onBooked();
+      if (data.conversation_id) {
+        onBooked(data.conversation_id);
       }
     } catch {
       setMessages([...next, { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' }]);

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../api/axiosConfig';
 import { Dialog, DialogTitle, DialogActions, DialogContent, TextField, Box, Button } from '@mui/material';
-import { CloseOutlined } from '@mui/icons-material';
+import { CloseOutlined, Chat } from '@mui/icons-material';
 import { Appointment } from './AppointmentList';
 
 interface Suggested {
@@ -35,6 +36,7 @@ const localOffsetStr = () => {
 };
 
 const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointment, isPending = false, suggested }: BookingProps) => {
+  const navigate = useNavigate();
   const [date, setDate] = useState(appointment ? toDatePart(appointment.date) : (suggested?.date ?? new Date().toISOString().split('T')[0]));
   const [time, setTime] = useState(appointment ? toTimePart(appointment.date) : (suggested?.time ?? '09:00'));
   const [duration, setDuration] = useState(appointment?.duration ?? suggested?.duration ?? 0);
@@ -109,8 +111,23 @@ const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointmen
           />
         </Box>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={handleSubmit} autoFocus>{isPending ? 'Send Invitation' : 'Book'}</Button>
+      <DialogActions sx={{ justifyContent: 'space-between', px: 2, pb: 2 }}>
+        {!isPending && (
+          <Button
+            startIcon={<Chat />}
+            onClick={async () => {
+              const res = await axiosInstance.post('/conversations', { client_id: clientId, support_worker_id: supportWorkerId });
+              onClose();
+              navigate(`/messages/${res.data.id}`);
+            }}
+            sx={{ color: '#7B2FBE' }}
+          >
+            Send Message
+          </Button>
+        )}
+        <Button onClick={handleSubmit} autoFocus sx={{ ml: 'auto' }}>
+          {isPending ? 'Send Invitation' : 'Book'}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -4,12 +4,22 @@ import { Dialog, DialogTitle, DialogActions, DialogContent, TextField, Box, Butt
 import { CloseOutlined } from '@mui/icons-material';
 import { Appointment } from './AppointmentList';
 
+interface Suggested {
+  date?: string | null;
+  time?: string | null;
+  duration?: number | null;
+  location?: string | null;
+  notes?: string | null;
+}
+
 interface BookingProps {
   clientId: number;
   supportWorkerId: number;
   onClose: () => void;
   onSuccess: (date: string) => void;
   appointment?: Appointment;
+  isPending?: boolean;
+  suggested?: Suggested;
 }
 
 const toDatePart = (iso: string) => new Date(iso).toLocaleDateString('en-CA');
@@ -24,12 +34,12 @@ const localOffsetStr = () => {
   return `${sign}${String(Math.floor(abs / 60)).padStart(2, '0')}:${String(abs % 60).padStart(2, '0')}`;
 };
 
-const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointment }: BookingProps) => {
-  const [date, setDate] = useState(appointment ? toDatePart(appointment.date) : new Date().toISOString().split('T')[0]);
-  const [time, setTime] = useState(appointment ? toTimePart(appointment.date) : '09:00');
-  const [duration, setDuration] = useState(appointment?.duration ?? 0);
-  const [location, setLocation] = useState(appointment?.location ?? '');
-  const [notes, setNotes] = useState(appointment?.notes ?? '');
+const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointment, isPending = false, suggested }: BookingProps) => {
+  const [date, setDate] = useState(appointment ? toDatePart(appointment.date) : (suggested?.date ?? new Date().toISOString().split('T')[0]));
+  const [time, setTime] = useState(appointment ? toTimePart(appointment.date) : (suggested?.time ?? '09:00'));
+  const [duration, setDuration] = useState(appointment?.duration ?? suggested?.duration ?? 0);
+  const [location, setLocation] = useState(appointment?.location ?? suggested?.location ?? '');
+  const [notes, setNotes] = useState(appointment?.notes ?? suggested?.notes ?? '');
 
   const handleSubmit = async () => {
     const datetime = `${date}T${time}:00${localOffsetStr()}`;
@@ -47,6 +57,7 @@ const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointmen
             notes,
             client_id: clientId,
             support_worker_id: supportWorkerId,
+            status: isPending ? 'pending' : 'approved',
           }
         });
       }
@@ -61,7 +72,7 @@ const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointmen
     <Dialog open={true} aria-labelledby="booking-dialog-title">
       <DialogTitle id="booking-dialog-title">
         <Box display='flex' justifyContent='space-between' alignItems='center'>
-          {appointment ? "Edit Appointment" : "Book Appointment"}
+          {appointment ? "Edit Appointment" : isPending ? "Send Appointment Invitation" : "Book Appointment"}
           <CloseOutlined sx={{ color: 'text.secondary' }} onClick={onClose} />
         </Box>
       </DialogTitle>
@@ -99,7 +110,7 @@ const BookingForm = ({ clientId, supportWorkerId, onClose, onSuccess, appointmen
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleSubmit} autoFocus>Book</Button>
+        <Button onClick={handleSubmit} autoFocus>{isPending ? 'Send Invitation' : 'Book'}</Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/ClientList.tsx
+++ b/src/components/ClientList.tsx
@@ -67,7 +67,7 @@ const ClientList = () => {
         </TableContainer>
       </Box>
       {agentOpen && (
-        <BookingAgent open={agentOpen} onClose={() => setAgentOpen(false)} onBooked={() => setAgentOpen(false)} isClient={false} />
+        <BookingAgent open={agentOpen} onClose={() => setAgentOpen(false)} onBooked={(convId) => { setAgentOpen(false); navigate(`/messages/${convId}`); }} isClient={false} />
       )}
     </Container>
   );

--- a/src/components/ClientProfilePage.tsx
+++ b/src/components/ClientProfilePage.tsx
@@ -4,7 +4,7 @@ import {
   Box, Typography, Avatar, Chip, Button, Paper, Grid, Divider,
   CircularProgress, TextField, MenuItem,
 } from '@mui/material';
-import { LocationOn, Phone, Email, Favorite, Warning, ArrowBack, CalendarMonth, Edit, Save, Cancel } from '@mui/icons-material';
+import { LocationOn, Phone, Email, Favorite, Warning, ArrowBack, CalendarMonth, Edit, Save, Cancel, Chat } from '@mui/icons-material';
 import axiosInstance from '../api/axiosConfig';
 import { Client } from '../context/AuthContext';
 import { useAuth } from '../context/AuthContext';
@@ -91,9 +91,22 @@ const ClientProfilePage = () => {
                 </>
               )}
               {supportWorker && !editing && (
-                <Button variant="contained" startIcon={<CalendarMonth />} onClick={() => setShowBookingForm(true)} sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a0dad' } }}>
-                  Book Appointment
-                </Button>
+                <>
+                  <Button
+                    variant="outlined"
+                    startIcon={<Chat />}
+                    onClick={async () => {
+                      const res = await axiosInstance.post('/conversations', { client_id: client.id });
+                      navigate(`/messages/${res.data.id}`);
+                    }}
+                    sx={{ borderColor: '#7B2FBE', color: '#7B2FBE' }}
+                  >
+                    Message
+                  </Button>
+                  <Button variant="contained" startIcon={<CalendarMonth />} onClick={() => setShowBookingForm(true)} sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a0dad' } }}>
+                    Book Appointment
+                  </Button>
+                </>
               )}
             </Box>
           </Box>

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box, Typography, Paper, Avatar, Divider, CircularProgress, Chip,
+} from '@mui/material';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+interface ConversationSummary {
+  id: number;
+  client: { id: number; first_name: string; last_name: string };
+  support_worker: { id: number; first_name: string; last_name: string };
+  messages: { content: string; created_at: string }[];
+}
+
+const ConversationList = () => {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { client } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    axiosInstance.get('/conversations')
+      .then(res => setConversations(res.data))
+      .catch(err => console.error('Error fetching conversations:', err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <Box display="flex" justifyContent="center" mt={10}><CircularProgress sx={{ color: '#7B2FBE' }} /></Box>;
+
+  const otherName = (c: ConversationSummary) => client
+    ? `${c.support_worker.first_name} ${c.support_worker.last_name}`
+    : `${c.client.first_name} ${c.client.last_name}`;
+
+  const initials = (name: string) => name.split(' ').map(n => n[0]).join('').slice(0, 2);
+  const lastMessage = (c: ConversationSummary) => c.messages[c.messages.length - 1];
+
+  return (
+    <Box maxWidth={680} mx="auto" mt={5} px={2}>
+      <Typography variant="h4" fontWeight={700} mb={3}>Messages</Typography>
+      {conversations.length === 0 ? (
+        <Typography color="text.secondary" fontStyle="italic">No conversations yet. Start a chat from a support worker or client profile.</Typography>
+      ) : (
+        <Paper sx={{ borderRadius: 3, overflow: 'hidden' }}>
+          {conversations.map((conv, i) => {
+            const name = otherName(conv);
+            const last = lastMessage(conv);
+            return (
+              <Box key={conv.id}>
+                <Box
+                  sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2, cursor: 'pointer', '&:hover': { bgcolor: '#f3e8ff' } }}
+                  onClick={() => navigate(`/messages/${conv.id}`)}
+                >
+                  <Avatar sx={{ bgcolor: '#7B2FBE', width: 48, height: 48 }}>{initials(name)}</Avatar>
+                  <Box flex={1} minWidth={0}>
+                    <Typography fontWeight={600}>{name}</Typography>
+                    {last ? (
+                      <Typography variant="body2" color="text.secondary" noWrap>{last.content}</Typography>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary" fontStyle="italic">No messages yet</Typography>
+                    )}
+                  </Box>
+                  {last && (
+                    <Typography variant="caption" color="text.secondary" flexShrink={0}>
+                      {new Date(last.created_at).toLocaleDateString([], { month: 'short', day: 'numeric' })}
+                    </Typography>
+                  )}
+                </Box>
+                {i < conversations.length - 1 && <Divider />}
+              </Box>
+            );
+          })}
+        </Paper>
+      )}
+    </Box>
+  );
+};
+
+export default ConversationList;

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Box, Typography, Paper, Avatar, TextField, IconButton, CircularProgress,
+  Button, Chip,
+} from '@mui/material';
+import { Send, ArrowBack, CalendarMonth, Check, Close } from '@mui/icons-material';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+import BookingForm from './BookingForm';
+
+interface Message {
+  id: number;
+  content: string;
+  sender_type: 'client' | 'support_worker';
+  sender_id: number;
+  created_at: string;
+}
+
+interface PendingAppointment {
+  id: number;
+  date: string;
+  duration: number;
+  location: string;
+  notes: string;
+  status: string;
+}
+
+interface ConversationDetail {
+  id: number;
+  client: { id: number; first_name: string; last_name: string };
+  support_worker: { id: number; first_name: string; last_name: string };
+  messages: Message[];
+  appointments: PendingAppointment[];
+}
+
+const ConversationView = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { client, supportWorker } = useAuth();
+  const [conversation, setConversation] = useState<ConversationDetail | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [pendingAppointments, setPendingAppointments] = useState<PendingAppointment[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [aiTyping, setAiTyping] = useState(false);
+  const [showInviteForm, setShowInviteForm] = useState(false);
+  const [inviteSuggested, setInviteSuggested] = useState<any>(null);
+  const [fetchingSuggestion, setFetchingSuggestion] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const fetchConversation = () => {
+    axiosInstance.get(`/conversations/${id}`)
+      .then(res => {
+        setConversation(res.data);
+        setMessages(res.data.messages);
+        setPendingAppointments(res.data.appointments.filter((a: PendingAppointment) => a.status === 'pending'));
+      });
+  };
+
+  useEffect(() => { fetchConversation(); }, [id]);
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages, aiTyping]);
+
+  const triggerAiResponse = async (followUpsLeft = 2, isTopLevel = true) => {
+    if (isTopLevel) setAiTyping(true);
+    try {
+      const aiRes = await axiosInstance.post(`/conversations/${id}/ai_respond`);
+      setMessages(prev => [...prev, aiRes.data.message]);
+      if (aiRes.data.appointment) {
+        const appt = aiRes.data.appointment;
+        if (appt.status === 'approved' || appt.status === 'declined') {
+          setPendingAppointments(prev => prev.filter(a => a.id !== appt.id));
+        }
+      }
+      if (aiRes.data.continue && followUpsLeft > 0) {
+        await new Promise(r => setTimeout(r, 1200));
+        await triggerAiResponse(followUpsLeft - 1, false);
+      }
+    } finally {
+      if (isTopLevel) setAiTyping(false);
+    }
+  };
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || sending || aiTyping) return;
+    setSending(true);
+    setInput('');
+    try {
+      const res = await axiosInstance.post(`/conversations/${id}/messages`, { content: text });
+      setMessages(prev => [...prev, res.data]);
+      setSending(false);
+      await triggerAiResponse();
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleApprove = async (apptId: number) => {
+    await axiosInstance.patch(`/appointments/${apptId}/approve`);
+    setPendingAppointments(prev => prev.filter(a => a.id !== apptId));
+  };
+
+  const handleDecline = async (apptId: number) => {
+    await axiosInstance.patch(`/appointments/${apptId}/decline`);
+    setPendingAppointments(prev => prev.filter(a => a.id !== apptId));
+  };
+
+  const openInviteForm = async () => {
+    setFetchingSuggestion(true);
+    try {
+      const res = await axiosInstance.get(`/conversations/${id}/suggest_booking`);
+      setInviteSuggested(res.data);
+    } catch {
+      setInviteSuggested({});
+    } finally {
+      setFetchingSuggestion(false);
+      setShowInviteForm(true);
+    }
+  };
+
+  const handleInviteSent = async () => {
+    setShowInviteForm(false);
+    fetchConversation();
+    await triggerAiResponse();
+  };
+
+  if (!conversation) return <Box display="flex" justifyContent="center" mt={10}><CircularProgress sx={{ color: '#7B2FBE' }} /></Box>;
+
+  const mySenderType = client ? 'client' : 'support_worker';
+  const otherPerson = client ? conversation.support_worker : conversation.client;
+  const otherName = `${otherPerson.first_name} ${otherPerson.last_name}`;
+  const initials = otherName.split(' ').map(n => n[0]).join('').slice(0, 2);
+
+  return (
+    <Box maxWidth={720} mx="auto" mt={5} px={2} display="flex" flexDirection="column" height="calc(100vh - 120px)">
+      {/* Header */}
+      <Paper sx={{ p: 2, borderRadius: 3, mb: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <IconButton onClick={() => navigate('/messages')} sx={{ color: '#7B2FBE' }}><ArrowBack /></IconButton>
+        <Avatar sx={{ bgcolor: '#7B2FBE' }}>{initials}</Avatar>
+        <Typography variant="h6" fontWeight={600}>{otherName}</Typography>
+      </Paper>
+
+      {/* Pending invitations */}
+      {pendingAppointments.map(appt => (
+        <Paper key={appt.id} sx={{ p: 2, borderRadius: 3, border: '2px solid #7B2FBE', mb: 2 }}>
+          <Box display="flex" alignItems="center" gap={1} mb={1}>
+            <CalendarMonth sx={{ color: '#7B2FBE' }} />
+            <Typography fontWeight={600} color="#7B2FBE">Appointment Invitation</Typography>
+            <Chip label="Pending" size="small" sx={{ bgcolor: '#f3e8ff', color: '#7B2FBE' }} />
+          </Box>
+          <Typography variant="body2">
+            {new Date(appt.date).toLocaleString([], { dateStyle: 'full', timeStyle: 'short' })}
+            {appt.duration ? ` · ${appt.duration} min` : ''}
+            {appt.location ? ` · ${appt.location}` : ''}
+          </Typography>
+          {appt.notes && <Typography variant="caption" color="text.secondary">{appt.notes}</Typography>}
+          {supportWorker && (
+            <Box display="flex" gap={1} mt={1.5}>
+              <Button variant="contained" size="small" startIcon={<Check />} onClick={() => handleApprove(appt.id)} sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a27a3' } }}>Approve</Button>
+              <Button variant="outlined" size="small" startIcon={<Close />} onClick={() => handleDecline(appt.id)} color="error">Decline</Button>
+            </Box>
+          )}
+          {client && <Typography variant="caption" color="text.secondary" display="block" mt={1}>Waiting for response…</Typography>}
+        </Paper>
+      ))}
+
+      {/* Messages */}
+      <Paper sx={{ flex: 1, overflowY: 'auto', p: 2, borderRadius: 3, mb: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {messages.length === 0 && !aiTyping && (
+          <Typography color="text.secondary" fontStyle="italic" textAlign="center" mt={4}>Say hello to get started</Typography>
+        )}
+        {messages.map(msg => {
+          const isMine = msg.sender_type === mySenderType;
+          return (
+            <Box key={msg.id} display="flex" justifyContent={isMine ? 'flex-end' : 'flex-start'}>
+              <Box sx={{
+                maxWidth: '72%',
+                p: 1.5,
+                borderRadius: isMine ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
+                bgcolor: isMine ? '#7B2FBE' : '#f3e8ff',
+                color: isMine ? 'white' : 'text.primary',
+              }}>
+                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>{msg.content}</Typography>
+                <Typography variant="caption" sx={{ opacity: 0.7, display: 'block', textAlign: 'right', mt: 0.25 }}>
+                  {new Date(msg.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </Typography>
+              </Box>
+            </Box>
+          );
+        })}
+
+        {aiTyping && (
+          <Box display="flex" justifyContent="flex-start" alignItems="center" gap={1} pl={0.5}>
+            <Avatar sx={{ width: 28, height: 28, bgcolor: '#7B2FBE', fontSize: 11 }}>{initials}</Avatar>
+            <Box sx={{ bgcolor: '#f3e8ff', borderRadius: '16px 16px 16px 4px', px: 1.5, py: 1 }}>
+              <CircularProgress size={14} sx={{ color: '#7B2FBE' }} />
+            </Box>
+          </Box>
+        )}
+        <div ref={bottomRef} />
+      </Paper>
+
+      {/* Input */}
+      <Paper sx={{ p: 1.5, borderRadius: 3, display: 'flex', gap: 1, alignItems: 'flex-end' }}>
+        {client && (
+          <Button size="small" variant="outlined" startIcon={fetchingSuggestion ? <CircularProgress size={14} sx={{ color: '#7B2FBE' }} /> : <CalendarMonth />} onClick={openInviteForm}
+            disabled={fetchingSuggestion}
+            sx={{ borderColor: '#7B2FBE', color: '#7B2FBE', flexShrink: 0, mb: 0.25 }}>
+            Send Invitation
+          </Button>
+        )}
+        <TextField
+          fullWidth size="small" placeholder="Type a message…"
+          value={input} onChange={e => setInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); } }}
+          multiline maxRows={3} disabled={sending || aiTyping}
+        />
+        <IconButton onClick={sendMessage} disabled={!input.trim() || sending || aiTyping} sx={{ color: '#7B2FBE', mb: 0.25 }}>
+          <Send />
+        </IconButton>
+      </Paper>
+
+      {showInviteForm && conversation && client && (
+        <BookingForm
+          clientId={conversation.client.id}
+          supportWorkerId={conversation.support_worker.id}
+          onClose={() => { setShowInviteForm(false); setInviteSuggested(null); }}
+          onSuccess={handleInviteSent}
+          isPending
+          suggested={inviteSuggested}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default ConversationView;

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -68,7 +68,9 @@ const ConversationView = () => {
       setMessages(prev => [...prev, aiRes.data.message]);
       if (aiRes.data.appointment) {
         const appt = aiRes.data.appointment;
-        if (appt.status === 'approved' || appt.status === 'declined') {
+        if (appt.status === 'pending') {
+          setPendingAppointments(prev => [...prev.filter(a => a.id !== appt.id), appt]);
+        } else if (appt.status === 'approved' || appt.status === 'declined') {
           setPendingAppointments(prev => prev.filter(a => a.id !== appt.id));
         }
       }
@@ -171,6 +173,16 @@ const ConversationView = () => {
           <Typography color="text.secondary" fontStyle="italic" textAlign="center" mt={4}>Say hello to get started</Typography>
         )}
         {messages.map(msg => {
+          if (msg.content.startsWith('[SYS]')) {
+            const text = msg.content.replace('[SYS]', '').trim();
+            return (
+              <Box key={msg.id} display="flex" justifyContent="center" my={0.5}>
+                <Box sx={{ px: 2, py: 0.5 }}>
+                  <Typography variant="caption" sx={{ color: '#b0b0b0' }}>{text}</Typography>
+                </Box>
+              </Box>
+            );
+          }
           const isMine = msg.sender_type === mySenderType;
           return (
             <Box key={msg.id} display="flex" justifyContent={isMine ? 'flex-end' : 'flex-start'}>

--- a/src/components/InvitationsPage.tsx
+++ b/src/components/InvitationsPage.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box, Typography, Paper, Button, Chip, CircularProgress, Divider,
+} from '@mui/material';
+import { CalendarMonth, Check, Close, Chat, CheckCircle } from '@mui/icons-material';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+interface Invitation {
+  id: number;
+  date: string;
+  duration: number;
+  location: string;
+  notes: string;
+  status: string;
+  conversation_id: number | null;
+  client: { id: number; first_name: string; last_name: string };
+  support_worker: { id: number; first_name: string; last_name: string };
+}
+
+const InvitationCard = ({
+  inv, isClient, isSupportWorker, onApprove, onDecline, onChat,
+}: {
+  inv: Invitation;
+  isClient: boolean;
+  isSupportWorker: boolean;
+  onApprove?: (id: number) => void;
+  onDecline?: (id: number) => void;
+  onChat: (convId: number) => void;
+}) => {
+  const otherName = isClient
+    ? `${inv.support_worker.first_name} ${inv.support_worker.last_name}`
+    : `${inv.client.first_name} ${inv.client.last_name}`;
+  const accepted = inv.status === 'approved';
+
+  return (
+    <Box sx={{ p: 2.5 }}>
+      <Box display="flex" alignItems="center" gap={1} mb={1}>
+        {accepted
+          ? <CheckCircle sx={{ color: '#2e7d32', fontSize: 20 }} />
+          : <CalendarMonth sx={{ color: '#7B2FBE', fontSize: 20 }} />}
+        <Typography fontWeight={600}>{otherName}</Typography>
+        {accepted
+          ? <Chip label="Accepted" size="small" sx={{ bgcolor: '#e8f5e9', color: '#2e7d32' }} />
+          : <Chip label="Pending" size="small" sx={{ bgcolor: '#f3e8ff', color: '#7B2FBE' }} />}
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" mb={0.5}>
+        {new Date(inv.date).toLocaleString([], { dateStyle: 'full', timeStyle: 'short' })}
+        {inv.duration ? ` · ${inv.duration} min` : ''}
+        {inv.location ? ` · ${inv.location}` : ''}
+      </Typography>
+
+      {inv.notes && (
+        <Typography variant="caption" color="text.secondary" display="block" mb={1}>
+          {inv.notes}
+        </Typography>
+      )}
+
+      <Box display="flex" gap={1} mt={1.5} flexWrap="wrap" alignItems="center">
+        {isSupportWorker && !accepted && onApprove && onDecline && (
+          <>
+            <Button variant="contained" size="small" startIcon={<Check />}
+              onClick={() => onApprove(inv.id)}
+              sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a27a3' } }}>
+              Approve
+            </Button>
+            <Button variant="outlined" size="small" startIcon={<Close />}
+              onClick={() => onDecline(inv.id)} color="error">
+              Decline
+            </Button>
+          </>
+        )}
+        {isClient && !accepted && (
+          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
+            Waiting for response…
+          </Typography>
+        )}
+        {inv.conversation_id && (
+          <Button variant="outlined" size="small" startIcon={<Chat />}
+            onClick={() => onChat(inv.conversation_id!)}
+            sx={{ borderColor: '#7B2FBE', color: '#7B2FBE', ml: 'auto' }}>
+            View Chat
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const InvitationsPage = () => {
+  const { client, supportWorker } = useAuth();
+  const navigate = useNavigate();
+  const [pending, setPending] = useState<Invitation[]>([]);
+  const [accepted, setAccepted] = useState<Invitation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      axiosInstance.get('/appointments/pending'),
+      axiosInstance.get('/appointments/recently_accepted'),
+    ]).then(([p, a]) => {
+      setPending(p.data);
+      setAccepted(a.data);
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, []);
+
+  const handleApprove = async (id: number) => {
+    await axiosInstance.patch(`/appointments/${id}/approve`);
+    setPending(prev => prev.filter(a => a.id !== id));
+  };
+
+  const handleDecline = async (id: number) => {
+    await axiosInstance.patch(`/appointments/${id}/decline`);
+    setPending(prev => prev.filter(a => a.id !== id));
+  };
+
+  if (loading) return <Box display="flex" justifyContent="center" mt={10}><CircularProgress sx={{ color: '#7B2FBE' }} /></Box>;
+
+  const isClient = !!client;
+  const isSupportWorker = !!supportWorker;
+  const isEmpty = pending.length === 0 && accepted.length === 0;
+
+  return (
+    <Box maxWidth={680} mx="auto" mt={5} px={2}>
+      <Typography variant="h4" fontWeight={700} mb={3}>Invitations</Typography>
+
+      {isEmpty ? (
+        <Paper sx={{ p: 4, borderRadius: 3, textAlign: 'center' }}>
+          <CalendarMonth sx={{ fontSize: 48, color: '#d0b0f0', mb: 1 }} />
+          <Typography color="text.secondary">No invitations yet.</Typography>
+        </Paper>
+      ) : (
+        <>
+          {pending.length > 0 && (
+            <Paper sx={{ borderRadius: 3, overflow: 'hidden', mb: 3 }}>
+              <Box sx={{ px: 2.5, pt: 2, pb: 1 }}>
+                <Typography variant="overline" color="text.secondary" fontWeight={600}>
+                  {isSupportWorker ? 'Incoming — Awaiting Your Response' : 'Outgoing — Awaiting Response'}
+                </Typography>
+              </Box>
+              <Divider />
+              {pending.map((inv, i) => (
+                <Box key={inv.id}>
+                  <InvitationCard
+                    inv={inv} isClient={isClient} isSupportWorker={isSupportWorker}
+                    onApprove={handleApprove} onDecline={handleDecline}
+                    onChat={(convId) => navigate(`/messages/${convId}`)}
+                  />
+                  {i < pending.length - 1 && <Divider />}
+                </Box>
+              ))}
+            </Paper>
+          )}
+
+          {accepted.length > 0 && (
+            <Paper sx={{ borderRadius: 3, overflow: 'hidden' }}>
+              <Box sx={{ px: 2.5, pt: 2, pb: 1 }}>
+                <Typography variant="overline" color="text.secondary" fontWeight={600}>Recently Accepted</Typography>
+              </Box>
+              <Divider />
+              {accepted.map((inv, i) => (
+                <Box key={inv.id}>
+                  <InvitationCard
+                    inv={{ ...inv, status: 'approved' }} isClient={isClient} isSupportWorker={isSupportWorker}
+                    onChat={(convId) => navigate(`/messages/${convId}`)}
+                  />
+                  {i < accepted.length - 1 && <Divider />}
+                </Box>
+              ))}
+            </Paper>
+          )}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default InvitationsPage;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,16 +1,37 @@
-import React from 'react';
-import { AppBar, Toolbar, Typography, Button, Box, IconButton, Avatar, Tooltip } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { AppBar, Toolbar, Typography, Button, Box, IconButton, Avatar, Tooltip, Badge } from '@mui/material';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import axiosInstance from '../api/axiosConfig';
 
 const Navbar = () => {
   const auth = useAuth();
- const navigate = useNavigate();
+  const navigate = useNavigate();
+  const [unreadMessages, setUnreadMessages] = useState(0);
+  const [invitationsBadge, setInvitationsBadge] = useState(0);
 
-const handleLogout = () => {
-  auth?.setUser(null);
-  navigate('/login')
-}
+  useEffect(() => {
+    if (!auth.client && !auth.supportWorker) return;
+
+    const fetchNotifications = () => {
+      axiosInstance.get('/notifications')
+        .then(res => {
+          setUnreadMessages(res.data.unread_messages);
+          setInvitationsBadge(res.data.pending_invitations + (res.data.recently_accepted ?? 0));
+        })
+        .catch(() => {});
+    };
+
+    fetchNotifications();
+    const interval = setInterval(fetchNotifications, 15000);
+    return () => clearInterval(interval);
+  }, [auth.client, auth.supportWorker]);
+
+  const handleLogout = () => {
+    auth?.setUser(null);
+    navigate('/login');
+  };
+
   return (
     <AppBar sx={{ backgroundColor: '#7B2FBE', boxShadow: 'none' }}>
       <Toolbar>
@@ -18,7 +39,21 @@ const handleLogout = () => {
         {auth.supportWorker && <Button color="inherit" component={Link} to="/clients">Clients</Button>}
         <Button color="inherit" component={Link} to="/support-workers">Support Workers</Button>
         <Button color="inherit" component={Link} to="/appointments">Appointments</Button>
-        
+        {(auth.client || auth.supportWorker) && (
+          <Button color="inherit" component={Link} to="/messages" onClick={() => setUnreadMessages(0)}>
+            <Badge badgeContent={unreadMessages} color="error" max={9}>
+              Messages
+            </Badge>
+          </Button>
+        )}
+        {(auth.client || auth.supportWorker) && (
+          <Button color="inherit" component={Link} to="/invitations" onClick={() => setInvitationsBadge(0)}>
+            <Badge badgeContent={invitationsBadge} color="error" max={9}>
+              Invitations
+            </Badge>
+          </Button>
+        )}
+
         <Box sx={{ flexGrow: 1 }} />
         {auth.user ? (
           <>
@@ -26,7 +61,7 @@ const handleLogout = () => {
               sx={{ mr: 2, cursor: (auth.client || auth.supportWorker) ? 'pointer' : 'default', '&:hover': { textDecoration: (auth.client || auth.supportWorker) ? 'underline' : 'none' } }}
               onClick={() => {
                 if (auth.client) navigate(`/clients/${auth.client.id}`);
-                else if (auth.supportWorker) navigate(`/support-workers/${auth.supportWorker.id}`);
+                else if (auth.supportWorker) navigate(`/support-workers/${auth.supportWorker!.id}`);
               }}
             >
               Welcome, {auth.user.first_name}
@@ -57,6 +92,6 @@ const handleLogout = () => {
       </Toolbar>
     </AppBar>
   );
-}
+};
 
 export default Navbar;

--- a/src/components/SupportWorkerList.tsx
+++ b/src/components/SupportWorkerList.tsx
@@ -70,7 +70,7 @@ const SupportWorkerList = () => {
         </TableContainer>
       </Box>
       {agentOpen && (
-        <BookingAgent open={agentOpen} onClose={() => setAgentOpen(false)} onBooked={() => setAgentOpen(false)} isClient={true} />
+        <BookingAgent open={agentOpen} onClose={() => setAgentOpen(false)} onBooked={(convId) => { setAgentOpen(false); navigate(`/messages/${convId}`); }} isClient={true} />
       )}
     </Container>
   );

--- a/src/components/SupportWorkerProfilePage.tsx
+++ b/src/components/SupportWorkerProfilePage.tsx
@@ -4,7 +4,7 @@ import {
   Box, Typography, Avatar, Chip, Button, Paper, Grid, Divider,
   CircularProgress, TextField, MenuItem,
 } from '@mui/material';
-import { LocationOn, Phone, Email, Work, Schedule, ArrowBack, Edit, Save, Cancel } from '@mui/icons-material';
+import { LocationOn, Phone, Email, Work, Schedule, ArrowBack, Edit, Save, Cancel, Chat } from '@mui/icons-material';
 import axiosInstance from '../api/axiosConfig';
 import { SupportWorker } from '../context/AuthContext';
 import { useAuth } from '../context/AuthContext';
@@ -94,9 +94,22 @@ const SupportWorkerProfilePage = () => {
                 </>
               )}
               {client && !editing && (
-                <Button variant="contained" onClick={() => setShowBookingForm(true)} sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a0dad' } }}>
-                  Book Appointment
-                </Button>
+                <>
+                  <Button
+                    variant="outlined"
+                    startIcon={<Chat />}
+                    onClick={async () => {
+                      const res = await axiosInstance.post('/conversations', { support_worker_id: worker.id });
+                      navigate(`/messages/${res.data.id}`);
+                    }}
+                    sx={{ borderColor: '#7B2FBE', color: '#7B2FBE' }}
+                  >
+                    Message
+                  </Button>
+                  <Button variant="contained" onClick={() => setShowBookingForm(true)} sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a0dad' } }}>
+                    Book Appointment
+                  </Button>
+                </>
               )}
             </Box>
           </Box>


### PR DESCRIPTION
## Summary

- **Chat messaging** — clients and support workers can message each other; the other party's responses are AI-simulated by Claude (no simulation UI — feels like a real conversation)
- **AI follow-ups** — if Claude promises to share something, it sends a follow-up automatically using a `[CONTINUE]` signal without waiting for the user to nudge it
- **Appointment invitations** — clients send pending invitations via chat or the booking agent; support workers approve/decline; an automated message is posted to the conversation on decision
- **Smart pre-fill** — clicking Send Invitation calls Claude to extract date/time/location/notes from the conversation before opening the booking form
- **Notifications** — Messages and Invitations nav badges poll every 15s for unread messages, pending invitations and recently accepted appointments
- **Invitations page** — dedicated page with Incoming/Outgoing/Recently Accepted sections and direct links to the related conversation
- **Booking agent updated** — now creates pending invitations and drops the user into the conversation instead of booking directly

## Test plan

- [ ] Log in as a client (e.g. `frederico@gmail.com` / `password123`), open a support worker profile and click Message — type a message and verify AI responds as that worker
- [ ] Send an invitation from the chat — verify the form pre-fills with details discussed in the conversation
- [ ] Use the AI Booking Assistant on Support Workers page — verify it sends an invitation and navigates to the conversation
- [ ] Log in as a support worker (e.g. `olivia.williams@gmail.com` / `password123`) — check Invitations badge and approve an invitation, verify automated message appears in chat
- [ ] Verify the client sees a badge on Invitations and a green "Recently Accepted" entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)