### PR TITLE
Add missing specs for chat, invitations, and booking agent

### DIFF
--- a/src/components/BookingAgent.test.tsx
+++ b/src/components/BookingAgent.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BookingAgent from './BookingAgent';
+import axiosInstance from '../api/axiosConfig';
+
+jest.mock('../api/axiosConfig');
+const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+const mockOnClose = jest.fn();
+const mockOnBooked = jest.fn();
+
+const renderComponent = (isClient = true) =>
+  render(<BookingAgent open onClose={mockOnClose} onBooked={mockOnBooked} isClient={isClient} />);
+
+describe('BookingAgent', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows client welcome message when isClient is true', () => {
+    renderComponent(true);
+    expect(screen.getByText(/kind of support you're looking for/i)).toBeInTheDocument();
+  });
+
+  it('shows support worker welcome message when isClient is false', () => {
+    renderComponent(false);
+    expect(screen.getByText(/which client you'd like to book with/i)).toBeInTheDocument();
+  });
+
+  it('renders the text input field', () => {
+    renderComponent();
+    expect(screen.getByPlaceholderText(/Describe what you need/i)).toBeInTheDocument();
+  });
+
+  const getSendButton = () => screen.getByTestId('SendIcon').closest('button') as HTMLElement;
+
+  it('sends a message and shows agent reply', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { message: 'I found Olivia Williams for you!', conversation_id: null } });
+    renderComponent();
+    await userEvent.type(screen.getByPlaceholderText(/Describe what you need/i), 'I need elderly care support');
+    await userEvent.click(getSendButton());
+    await waitFor(() => expect(screen.getByText('I found Olivia Williams for you!')).toBeInTheDocument());
+  });
+
+  it('posts message history and timezone to /ai_booking/chat', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { message: 'Great!', conversation_id: null } });
+    renderComponent();
+    await userEvent.type(screen.getByPlaceholderText(/Describe what you need/i), 'Hello');
+    await userEvent.click(getSendButton());
+    await waitFor(() => {
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/ai_booking/chat',
+        expect.objectContaining({
+          messages: expect.any(Array),
+          timezone: expect.any(String),
+        })
+      );
+    });
+  });
+
+  it('calls onBooked with conversation_id when agent returns one', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { message: 'Booking created!', conversation_id: 42 } });
+    renderComponent();
+    await userEvent.type(screen.getByPlaceholderText(/Describe what you need/i), 'Book Olivia');
+    await userEvent.click(getSendButton());
+    await waitFor(() => expect(mockOnBooked).toHaveBeenCalledWith(42));
+  });
+
+  it('shows error message when API call fails', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+    renderComponent();
+    await userEvent.type(screen.getByPlaceholderText(/Describe what you need/i), 'Hello');
+    await userEvent.click(getSendButton());
+    await waitFor(() => expect(screen.getByText(/something went wrong/i)).toBeInTheDocument());
+  });
+
+  it('disables send button when input is empty', () => {
+    renderComponent();
+    expect(getSendButton()).toBeDisabled();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    renderComponent();
+    await userEvent.click(screen.getByTestId('CloseIcon').closest('button')!);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/BookingForm.test.tsx
+++ b/src/components/BookingForm.test.tsx
@@ -1,69 +1,123 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import BookingForm from './BookingForm';
 import axiosInstance from '../api/axiosConfig';
 
 jest.mock('../api/axiosConfig');
 const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
 
+const mockOnClose = jest.fn();
+const mockOnSuccess = jest.fn();
+
+const renderForm = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <BookingForm clientId={1} supportWorkerId={1} onClose={mockOnClose} onSuccess={mockOnSuccess} {...props} />
+    </MemoryRouter>
+  );
+
 describe('BookingForm', () => {
-  const mockOnClose = jest.fn();
-  const mockOnSuccess = jest.fn();
-
   beforeEach(() => {
-    render(<BookingForm clientId={1} supportWorkerId={1} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
     mockedAxios.post.mockResolvedValue({ data: {} });
+    mockedAxios.patch.mockResolvedValue({ data: {} });
   });
+  afterEach(() => jest.clearAllMocks());
 
-  afterEach(() => { jest.clearAllMocks(); });
-
-  it('renders the title', () => {
+  it('renders "Book Appointment" title by default', () => {
+    renderForm();
     expect(screen.getByText(/Book Appointment/i)).toBeInTheDocument();
   });
 
-  it('renders the date field', () => {
+  it('renders "Send Appointment Invitation" title when isPending', () => {
+    renderForm({ isPending: true });
+    expect(screen.getByText(/Send Appointment Invitation/i)).toBeInTheDocument();
+  });
+
+  it('renders "Edit Appointment" title when appointment is provided', () => {
+    const appt = { id: 5, date: '2026-06-01T10:00:00Z', duration: 60, location: 'Sydney', notes: 'Test' };
+    renderForm({ appointment: appt as any });
+    expect(screen.getByText(/Edit Appointment/i)).toBeInTheDocument();
+  });
+
+  it('renders all form fields', () => {
+    renderForm();
     expect(screen.getByLabelText(/Date/i)).toBeInTheDocument();
-  });
-
-  it('renders the duration field', () => {
     expect(screen.getByLabelText(/Duration/i)).toBeInTheDocument();
-  });
-
-  it('renders the location field', () => {
     expect(screen.getByLabelText(/Location/i)).toBeInTheDocument();
-  });
-
-  it('renders the notes field', () => {
     expect(screen.getByLabelText(/Notes/i)).toBeInTheDocument();
   });
 
-  it('renders the Book button', () => {
-    expect(screen.getByRole('button', { name: /Book/i })).toBeInTheDocument();
+  it('pre-fills fields from suggested prop', () => {
+    renderForm({ suggested: { date: '2026-06-10', time: '11:00', duration: 90, location: 'Brisbane', notes: 'Bring ID' } });
+    expect((screen.getByLabelText(/Location/i) as HTMLInputElement).value).toBe('Brisbane');
+    expect((screen.getByLabelText(/Notes/i) as HTMLInputElement).value).toBe('Bring ID');
   });
 
-  it('submits the form with the correct data', async () => {
-    userEvent.type(screen.getByLabelText(/Duration/i), '30');
-    userEvent.type(screen.getByLabelText(/Location/i), 'Melbourne');
-    userEvent.type(screen.getByLabelText(/Notes/i), 'Some test notes');
-    userEvent.click(screen.getByRole('button', { name: /Book/i }));
+  it('pre-fills fields from appointment prop when editing', () => {
+    const appt = { id: 5, date: '2026-06-01T10:00:00Z', duration: 45, location: 'Melbourne', notes: 'Edited notes' };
+    renderForm({ appointment: appt as any });
+    expect((screen.getByLabelText(/Location/i) as HTMLInputElement).value).toBe('Melbourne');
+    expect((screen.getByLabelText(/Notes/i) as HTMLInputElement).value).toBe('Edited notes');
+  });
+
+  it('shows "Book" button by default', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /^Book$/i })).toBeInTheDocument();
+  });
+
+  it('shows "Send Invitation" button when isPending', () => {
+    renderForm({ isPending: true });
+    expect(screen.getByRole('button', { name: /Send Invitation/i })).toBeInTheDocument();
+  });
+
+  it('hides "Send Message" button when isPending', () => {
+    renderForm({ isPending: true });
+    expect(screen.queryByRole('button', { name: /Send Message/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "Send Message" button when not isPending', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /Send Message/i })).toBeInTheDocument();
+  });
+
+  it('submits with status "pending" when isPending', async () => {
+    renderForm({ isPending: true });
+    await userEvent.click(screen.getByRole('button', { name: /Send Invitation/i }));
     await waitFor(() => {
-      expect(mockedAxios.post).toHaveBeenCalledWith('/appointments', {
-        appointment: {
-          date: expect.any(String),
-          duration: 30,
-          location: 'Melbourne',
-          notes: 'Some test notes',
-          client_id: 1,
-          support_worker_id: 1,
-        }
-      });
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/appointments',
+        expect.objectContaining({ appointment: expect.objectContaining({ status: 'pending' }) })
+      );
     });
   });
 
-  it('closes the modal after submission', async () => {
-    userEvent.click(screen.getByRole('button', { name: /Book/i }));
-    await waitFor(() => { expect(mockOnSuccess).toHaveBeenCalled(); });
-    await waitFor(() => { expect(mockOnClose).toHaveBeenCalled(); });
+  it('submits with status "approved" by default', async () => {
+    renderForm();
+    await userEvent.click(screen.getByRole('button', { name: /^Book$/i }));
+    await waitFor(() => {
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/appointments',
+        expect.objectContaining({ appointment: expect.objectContaining({ status: 'approved' }) })
+      );
+    });
+  });
+
+  it('calls patch when editing an existing appointment', async () => {
+    const appt = { id: 5, date: '2026-06-01T10:00:00Z', duration: 60, location: 'Sydney', notes: '' };
+    renderForm({ appointment: appt as any });
+    await userEvent.click(screen.getByRole('button', { name: /^Book$/i }));
+    await waitFor(() => {
+      expect(mockedAxios.patch).toHaveBeenCalledWith('/appointments/5', expect.any(Object));
+    });
+  });
+
+  it('calls onClose and onSuccess after successful submission', async () => {
+    renderForm();
+    await userEvent.click(screen.getByRole('button', { name: /^Book$/i }));
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(mockOnSuccess).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/ConversationList.test.tsx
+++ b/src/components/ConversationList.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ConversationList from './ConversationList';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+jest.mock('../api/axiosConfig');
+jest.mock('../context/AuthContext');
+
+const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const mockClient = { id: 1, first_name: 'Jane', last_name: 'Doe' } as any;
+
+const makeConversation = (id: number, lastContent?: string) => ({
+  id,
+  client: { id: 1, first_name: 'Jane', last_name: 'Doe' },
+  support_worker: { id: 2, first_name: 'Olivia', last_name: 'Williams' },
+  messages: lastContent
+    ? [{ content: lastContent, created_at: '2026-05-01T10:00:00Z' }]
+    : [],
+});
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter>
+      <ConversationList />
+    </MemoryRouter>
+  );
+
+describe('ConversationList', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({ client: mockClient, supportWorker: null } as any);
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows loading spinner initially', () => {
+    mockedAxios.get.mockReturnValue(new Promise(() => {}));
+    renderComponent();
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+  });
+
+  it('shows empty state when there are no conversations', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: [] });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText(/No conversations yet/i)).toBeInTheDocument());
+  });
+
+  it('renders a conversation with the other party name', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: [makeConversation(1, 'Hello!')] });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText('Olivia Williams')).toBeInTheDocument());
+  });
+
+  it('shows last message preview', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: [makeConversation(1, 'See you tomorrow')] });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText('See you tomorrow')).toBeInTheDocument());
+  });
+
+  it('shows "No messages yet" when conversation has no messages', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: [makeConversation(1)] });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText(/No messages yet/i)).toBeInTheDocument());
+  });
+
+  it('renders multiple conversations', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: [makeConversation(1, 'Hi'), makeConversation(2, 'Hey')],
+    });
+    renderComponent();
+    await waitFor(() => {
+      // Both show same worker name (same mock data) — just check count
+      expect(screen.getAllByText('Olivia Williams')).toHaveLength(2);
+    });
+  });
+
+  it('shows client name when user is a support worker', async () => {
+    mockedUseAuth.mockReturnValue({ client: null, supportWorker: { id: 2 } } as any);
+    mockedAxios.get.mockResolvedValueOnce({ data: [makeConversation(1, 'Hello')] });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+  });
+});

--- a/src/components/ConversationView.test.tsx
+++ b/src/components/ConversationView.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ConversationView from './ConversationView';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+jest.mock('../api/axiosConfig');
+jest.mock('../context/AuthContext');
+jest.mock('./BookingForm', () => () => <div data-testid="booking-form" />);
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const baseConversation = {
+  id: 1,
+  client: { id: 1, first_name: 'Jane', last_name: 'Doe' },
+  support_worker: { id: 2, first_name: 'Olivia', last_name: 'Williams' },
+  messages: [
+    { id: 10, content: 'Hello there!', sender_type: 'client', sender_id: 1, created_at: '2026-05-01T10:00:00Z' },
+  ],
+  appointments: [],
+};
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter initialEntries={['/messages/1']}>
+      <Routes>
+        <Route path="/messages/:id" element={<ConversationView />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('ConversationView', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('as a client', () => {
+    beforeEach(() => {
+      mockedUseAuth.mockReturnValue({ client: { id: 1 }, supportWorker: null } as any);
+    });
+
+    it('shows loading spinner before data loads', () => {
+      mockedAxios.get.mockReturnValue(new Promise(() => {}));
+      renderComponent();
+      expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+    });
+
+    it('renders the other party name in the header', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: baseConversation });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText('Olivia Williams')).toBeInTheDocument());
+    });
+
+    it('renders existing messages', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: baseConversation });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText('Hello there!')).toBeInTheDocument());
+    });
+
+    it('shows system messages as light text without a bubble', async () => {
+      const conv = {
+        ...baseConversation,
+        messages: [{ id: 11, content: '[SYS]✓ Appointment confirmed', sender_type: 'client', sender_id: 1, created_at: '2026-05-01T10:05:00Z' }],
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: conv });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText('✓ Appointment confirmed')).toBeInTheDocument());
+    });
+
+    it('shows "Send Invitation" button for clients', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: baseConversation });
+      renderComponent();
+      await waitFor(() => expect(screen.getByRole('button', { name: /Send Invitation/i })).toBeInTheDocument());
+    });
+
+    it('sends a message and triggers AI response', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: baseConversation });
+      mockedAxios.post
+        .mockResolvedValueOnce({ data: { id: 20, content: 'Hi!', sender_type: 'client', sender_id: 1, created_at: '2026-05-01T10:10:00Z' } })
+        .mockResolvedValueOnce({ data: { message: { id: 21, content: 'Hello!', sender_type: 'support_worker', sender_id: 2, created_at: '2026-05-01T10:11:00Z' }, continue: false, appointment: null } });
+
+      renderComponent();
+      await waitFor(() => screen.getByText('Hello there!'));
+      const input = screen.getByPlaceholderText(/Type a message/i);
+      await userEvent.type(input, 'Hi!');
+      // Submit via Enter key since the send IconButton has no accessible name
+      await userEvent.keyboard('{Enter}');
+      await waitFor(() => expect(screen.getByText('Hello!')).toBeInTheDocument());
+    });
+
+    it('renders a pending appointment invitation', async () => {
+      const conv = {
+        ...baseConversation,
+        appointments: [{ id: 5, date: '2026-06-01T10:00:00Z', duration: 60, location: 'Sydney', notes: '', status: 'pending' }],
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: conv });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText('Appointment Invitation')).toBeInTheDocument());
+    });
+
+    it('shows "Waiting for response…" text for clients on pending invitation', async () => {
+      const conv = {
+        ...baseConversation,
+        appointments: [{ id: 5, date: '2026-06-01T10:00:00Z', duration: 60, location: 'Sydney', notes: '', status: 'pending' }],
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: conv });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText(/Waiting for response/i)).toBeInTheDocument());
+    });
+
+    it('opens BookingForm when Send Invitation is clicked', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: baseConversation })
+        .mockResolvedValueOnce({ data: { date: '2026-06-10', time: '10:00' } });
+      renderComponent();
+      await waitFor(() => screen.getByRole('button', { name: /Send Invitation/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Send Invitation/i }));
+      await waitFor(() => expect(screen.getByTestId('booking-form')).toBeInTheDocument());
+    });
+  });
+
+  describe('as a support worker', () => {
+    beforeEach(() => {
+      mockedUseAuth.mockReturnValue({ client: null, supportWorker: { id: 2 } } as any);
+    });
+
+    it('shows the client name in the header', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: baseConversation });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    });
+
+    it('shows Approve and Decline buttons for support workers on pending invitations', async () => {
+      const conv = {
+        ...baseConversation,
+        appointments: [{ id: 5, date: '2026-06-01T10:00:00Z', duration: 60, location: 'Sydney', notes: '', status: 'pending' }],
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: conv });
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Approve/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Decline/i })).toBeInTheDocument();
+      });
+    });
+
+    it('removes invitation card after approval', async () => {
+      const conv = {
+        ...baseConversation,
+        appointments: [{ id: 5, date: '2026-06-01T10:00:00Z', duration: 60, location: 'Sydney', notes: '', status: 'pending' }],
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: conv });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+      renderComponent();
+      await waitFor(() => screen.getByRole('button', { name: /Approve/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Approve/i }));
+      await waitFor(() => expect(screen.queryByText('Appointment Invitation')).not.toBeInTheDocument());
+    });
+
+    it('hides "Send Invitation" button for support workers', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: baseConversation });
+      renderComponent();
+      await waitFor(() => screen.getByText('Jane Doe'));
+      expect(screen.queryByRole('button', { name: /Send Invitation/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Home.test.tsx
+++ b/src/components/Home.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Home from './Home';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+jest.mock('../api/axiosConfig');
+jest.mock('../context/AuthContext');
+jest.mock('../utils/formatDuration', () => ({ formatDuration: (d: number) => `${d} min` }));
+
+const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const makeAppointment = (id: number, overrides = {}) => ({
+  id,
+  date: '2026-06-10T09:00:00Z',
+  duration: 60,
+  location: 'Sydney',
+  notes: 'Test notes',
+  client_id: 1,
+  support_worker_id: 2,
+  client: { id: 1, first_name: 'Jane', last_name: 'Doe' },
+  support_worker: { id: 2, first_name: 'Olivia', last_name: 'Williams' },
+  ...overrides,
+});
+
+const clientDashboard = {
+  role: 'client',
+  upcoming_appointments: [makeAppointment(1)],
+  recent_appointments: [],
+  days_since_last_appointment: 5,
+  total_appointments: 3,
+  health_info: { health_conditions: 'Hypertension', medication: 'Lisinopril', allergies: '' },
+};
+
+const workerDashboard = {
+  role: 'support_worker',
+  upcoming_appointments: [makeAppointment(2)],
+  recent_appointments: [],
+  today_appointments: [],
+  hours_this_week: 12,
+  total_clients: 4,
+};
+
+const renderComponent = () =>
+  render(<MemoryRouter><Home /></MemoryRouter>);
+
+describe('Home — client dashboard', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({ user: { id: 1, first_name: 'Jane' }, client: { id: 1 }, supportWorker: null } as any);
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows loading spinner initially', () => {
+    mockedAxios.get.mockReturnValue(new Promise(() => {}));
+    renderComponent();
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+  });
+
+  it('renders the welcome heading with first name', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: clientDashboard });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText(/Welcome back, Jane/i)).toBeInTheDocument());
+  });
+
+  it('shows stat cards for upcoming, days since last, and total appointments', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: clientDashboard });
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Upcoming (7 days)')).toBeInTheDocument();
+      expect(screen.getByText('Days since last appointment')).toBeInTheDocument();
+      expect(screen.getByText('Total appointments')).toBeInTheDocument();
+    });
+  });
+
+  it('renders health info when present', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: clientDashboard });
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      expect(screen.getByText('Lisinopril')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the support worker name in upcoming appointments', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: clientDashboard });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText('Olivia Williams')).toBeInTheDocument());
+  });
+
+  it('opens edit BookingForm when edit icon is clicked', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: clientDashboard });
+    renderComponent();
+    await waitFor(() => screen.getByText('Olivia Williams'));
+    await userEvent.click(screen.getByTitle ? document.querySelector('[data-testid="EditOutlinedIcon"]')?.closest('button')! : screen.getAllByRole('button')[0]);
+    // BookingForm modal heading should appear
+    await waitFor(() => expect(screen.getByText(/Book Appointment|Edit/i)).toBeInTheDocument());
+  });
+
+  it('opens delete dialog when delete icon is clicked', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: clientDashboard });
+    renderComponent();
+    await waitFor(() => screen.getByText('Olivia Williams'));
+    const deleteBtn = document.querySelector('[data-testid="DeleteOutlinedIcon"]')?.closest('button') as HTMLElement;
+    if (deleteBtn) await userEvent.click(deleteBtn);
+    await waitFor(() => expect(screen.getByText(/Delete Appointment/i)).toBeInTheDocument());
+  });
+});
+
+describe('Home — support worker dashboard', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({ user: { id: 2, first_name: 'Olivia' }, client: null, supportWorker: { id: 2 } } as any);
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders support worker stat cards', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: workerDashboard });
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText("Today's appointments")).toBeInTheDocument();
+      expect(screen.getByText('Hours this week')).toBeInTheDocument();
+      expect(screen.getByText('Total clients')).toBeInTheDocument();
+    });
+  });
+
+  it('renders client name in upcoming appointments', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: workerDashboard });
+    renderComponent();
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+  });
+
+  it('shows rebook button for past appointments', async () => {
+    const dashboardWithPast = {
+      ...workerDashboard,
+      recent_appointments: [makeAppointment(3)],
+    };
+    mockedAxios.get.mockResolvedValueOnce({ data: dashboardWithPast });
+    renderComponent();
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="EventRepeatOutlinedIcon"]')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/InvitationsPage.test.tsx
+++ b/src/components/InvitationsPage.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import InvitationsPage from './InvitationsPage';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+jest.mock('../api/axiosConfig');
+jest.mock('../context/AuthContext');
+
+const mockedAxios = axiosInstance as jest.Mocked<typeof axiosInstance>;
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const makeInvitation = (id: number, status = 'pending') => ({
+  id,
+  date: '2026-06-01T10:00:00Z',
+  duration: 60,
+  location: 'Sydney',
+  notes: 'Bring medication list',
+  status,
+  conversation_id: 5,
+  client: { id: 1, first_name: 'Jane', last_name: 'Doe' },
+  support_worker: { id: 2, first_name: 'Olivia', last_name: 'Williams' },
+});
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter>
+      <InvitationsPage />
+    </MemoryRouter>
+  );
+
+describe('InvitationsPage', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('as a support worker', () => {
+    beforeEach(() => {
+      mockedUseAuth.mockReturnValue({ client: null, supportWorker: { id: 2 } } as any);
+    });
+
+    it('shows loading spinner initially', () => {
+      mockedAxios.get.mockReturnValue(new Promise(() => {}));
+      renderComponent();
+      expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no invitations exist', async () => {
+      mockedAxios.get.mockResolvedValue({ data: [] });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText(/No invitations yet/i)).toBeInTheDocument());
+    });
+
+    it('shows "Incoming — Awaiting Your Response" label for support workers', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText(/Incoming — Awaiting Your Response/i)).toBeInTheDocument());
+    });
+
+    it('renders Approve and Decline buttons for pending invitations', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Approve/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Decline/i })).toBeInTheDocument();
+      });
+    });
+
+    it('removes invitation from list after approval', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+      renderComponent();
+      await waitFor(() => screen.getByRole('button', { name: /Approve/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Approve/i }));
+      expect(mockedAxios.patch).toHaveBeenCalledWith('/appointments/1/approve');
+      await waitFor(() => expect(screen.queryByText('Olivia Williams')).not.toBeInTheDocument());
+    });
+
+    it('removes invitation from list after decline', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+      renderComponent();
+      await waitFor(() => screen.getByRole('button', { name: /Decline/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Decline/i }));
+      expect(mockedAxios.patch).toHaveBeenCalledWith('/appointments/1/decline');
+      await waitFor(() => expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument());
+    });
+  });
+
+  describe('as a client', () => {
+    beforeEach(() => {
+      mockedUseAuth.mockReturnValue({ client: { id: 1 }, supportWorker: null } as any);
+    });
+
+    it('shows "Outgoing — Awaiting Response" label for clients', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      renderComponent();
+      await waitFor(() => expect(screen.getByText(/Outgoing — Awaiting Response/i)).toBeInTheDocument());
+    });
+
+    it('shows "Waiting for response…" text instead of Approve/Decline buttons', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByText(/Waiting for response/i)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Approve/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows "Recently Accepted" section with Accepted chip', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [] })
+        .mockResolvedValueOnce({ data: [makeInvitation(2, 'approved')] });
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByText(/Recently Accepted/i)).toBeInTheDocument();
+        expect(screen.getByText('Accepted')).toBeInTheDocument();
+      });
+    });
+
+    it('renders View Chat button when conversation_id is present', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: [makeInvitation(1)] })
+        .mockResolvedValueOnce({ data: [] });
+      renderComponent();
+      await waitFor(() => expect(screen.getByRole('button', { name: /View Chat/i })).toBeInTheDocument());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **ConversationList**: loading state, empty state, last message preview, role-aware name display (client vs worker)
- **ConversationView**: full message rendering, `[SYS]` system message formatting, pending invitation cards, approve/decline, AI response trigger, BookingForm integration
- **InvitationsPage**: client vs support worker views, approve/decline interactions, Recently Accepted section
- **BookingAgent**: welcome message variants, send/receive flow, AI booking callback, error handling
- **Home dashboard**: client and worker dashboards, stat cards, health info panel, edit/delete/rebook actions
- **BookingForm**: updated to cover `isPending`, `suggested` pre-fill, edit mode, `status` field, and new Send Message button

All 63 tests pass.

## Test plan
- [x] Run `npm test` — 63 tests, 0 failures
- [x] Covers all new components added in PRs #17–#19
- [x] Mocks axios and AuthContext; no real network calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)