### PR TITLE
Add admin role and support worker vetting flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.19",
         "@mui/material": "^5.15.19",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3909,7 +3910,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3990,17 +3990,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@testing-library/react/node_modules/@types/react-dom": {
@@ -17056,6 +17045,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,12 +14,29 @@ import ClientProfilePage from './components/ClientProfilePage';
 import Navbar from './components/Navbar';
 import SignUp from './components/SignUp';
 import Login from './components/Login';
+import VettingAgent from './components/VettingAgent';
+import AdminDashboard from './components/AdminDashboard';
 import { AuthProvider, useAuth } from './context/AuthContext';
 
 const ClientsRoute = () => {
   const { client } = useAuth();
   if (client) return <Navigate to="/" replace />;
   return <ClientList />;
+};
+
+const AdminRoute = ({ children }: { children: React.ReactNode }) => {
+  const { user, loading } = useAuth();
+  if (loading) return null;
+  if (!user?.is_admin) return <Navigate to="/" replace />;
+  return <>{children}</>;
+};
+
+const VettingRoute = ({ children }: { children: React.ReactNode }) => {
+  const { user, supportWorker, loading } = useAuth();
+  if (loading) return null;
+  if (!user) return <Navigate to="/login" replace />;
+  if (supportWorker?.status !== 'pending') return <Navigate to="/" replace />;
+  return <>{children}</>;
 };
 
 const App = () => {
@@ -39,6 +56,8 @@ const App = () => {
             <Route path='/invitations' element={<SecureRoute><InvitationsPage /></SecureRoute>} />
             <Route path='/messages' element={<SecureRoute><ConversationList /></SecureRoute>} />
             <Route path='/messages/:id' element={<SecureRoute><ConversationView /></SecureRoute>} />
+            <Route path="/vetting" element={<VettingRoute><VettingAgent /></VettingRoute>} />
+            <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />
             <Route path="/signup" element={<SignUp />} />
             <Route path="/login" element={<Login />} />
           </Routes>

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -1,0 +1,218 @@
+import { useState, useEffect } from 'react';
+import {
+  Box, Typography, Paper, Tabs, Tab, Chip, Button, Divider,
+  CircularProgress, Avatar, Table, TableBody, TableCell, TableHead, TableRow,
+  Alert,
+} from '@mui/material';
+import { CheckCircle, Cancel, AdminPanelSettings, CalendarMonth } from '@mui/icons-material';
+import axiosInstance from '../api/axiosConfig';
+
+interface Application {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  location: string;
+  bio: string;
+  status: string;
+  police_check_number: string | null;
+  wwcc_number: string | null;
+  check_notes: string | null;
+  agent_recommendation: string | null;
+  specializations: { id: number; name: string }[];
+  user: { email: string };
+}
+
+interface Appointment {
+  id: number;
+  date: string;
+  duration: number;
+  location: string;
+  status: string;
+  client: { first_name: string; last_name: string } | null;
+  support_worker: { first_name: string; last_name: string } | null;
+}
+
+const AdminDashboard = () => {
+  const [tab, setTab] = useState(0);
+  const [applications, setApplications] = useState<Application[]>([]);
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [feedback, setFeedback] = useState<{ msg: string; type: 'success' | 'error' } | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      axiosInstance.get('/admin/applications'),
+      axiosInstance.get('/admin/appointments'),
+    ]).then(([a, appts]) => {
+      setApplications(a.data);
+      setAppointments(appts.data);
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, []);
+
+  const handleApprove = async (id: number) => {
+    await axiosInstance.patch(`/admin/applications/${id}/approve`);
+    setApplications(prev => prev.filter(a => a.id !== id));
+    setFeedback({ msg: 'Support worker approved and now visible to clients.', type: 'success' });
+  };
+
+  const handleReject = async (id: number) => {
+    await axiosInstance.patch(`/admin/applications/${id}/reject`);
+    setApplications(prev => prev.filter(a => a.id !== id));
+    setFeedback({ msg: 'Application rejected.', type: 'error' });
+  };
+
+  if (loading) return <Box display="flex" justifyContent="center" mt={10}><CircularProgress sx={{ color: '#7B2FBE' }} /></Box>;
+
+  return (
+    <Box maxWidth={960} mx="auto" mt={5} px={2}>
+      <Box display="flex" alignItems="center" gap={2} mb={3}>
+        <AdminPanelSettings sx={{ color: '#7B2FBE', fontSize: 36 }} />
+        <Typography variant="h4" fontWeight={700}>Admin Dashboard</Typography>
+      </Box>
+
+      {feedback && (
+        <Alert severity={feedback.type} sx={{ mb: 2 }} onClose={() => setFeedback(null)}>
+          {feedback.msg}
+        </Alert>
+      )}
+
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, '& .MuiTabs-indicator': { bgcolor: '#7B2FBE' }, '& .Mui-selected': { color: '#7B2FBE !important' } }}>
+        <Tab label={`Pending Applications (${applications.length})`} />
+        <Tab label={`All Appointments (${appointments.length})`} />
+      </Tabs>
+
+      {tab === 0 && (
+        <>
+          {applications.length === 0 ? (
+            <Paper sx={{ p: 4, borderRadius: 3, textAlign: 'center' }}>
+              <CheckCircle sx={{ fontSize: 48, color: '#d0b0f0', mb: 1 }} />
+              <Typography color="text.secondary">No pending applications.</Typography>
+            </Paper>
+          ) : (
+            applications.map(app => (
+              <Paper key={app.id} sx={{ p: 3, borderRadius: 3, mb: 2 }}>
+                <Box display="flex" alignItems="flex-start" gap={2}>
+                  <Avatar sx={{ bgcolor: '#7B2FBE', width: 48, height: 48 }}>
+                    {app.first_name[0]}{app.last_name[0]}
+                  </Avatar>
+                  <Box flex={1}>
+                    <Box display="flex" alignItems="center" gap={1} mb={0.5}>
+                      <Typography fontWeight={700}>{app.first_name} {app.last_name}</Typography>
+                      <Chip label="Pending" size="small" sx={{ bgcolor: '#f3e8ff', color: '#7B2FBE' }} />
+                      {app.agent_recommendation && (
+                        <Chip
+                          label={`Agent: ${app.agent_recommendation}`}
+                          size="small"
+                          sx={{
+                            bgcolor: app.agent_recommendation === 'approved' ? '#e8f5e9' : '#fff3e0',
+                            color: app.agent_recommendation === 'approved' ? '#2e7d32' : '#e65100',
+                          }}
+                        />
+                      )}
+                    </Box>
+                    <Typography variant="body2" color="text.secondary">{app.user?.email} · {app.location}</Typography>
+                    {app.bio && <Typography variant="body2" mt={0.5}>{app.bio}</Typography>}
+
+                    <Divider sx={{ my: 1.5 }} />
+
+                    <Box display="flex" gap={4} flexWrap="wrap">
+                      <Box>
+                        <Typography variant="caption" color="text.secondary" fontWeight={600}>POLICE CHECK</Typography>
+                        <Typography variant="body2">{app.police_check_number ?? <em>Not provided</em>}</Typography>
+                      </Box>
+                      <Box>
+                        <Typography variant="caption" color="text.secondary" fontWeight={600}>WWCC</Typography>
+                        <Typography variant="body2">{app.wwcc_number ?? <em>Not provided</em>}</Typography>
+                      </Box>
+                    </Box>
+
+                    {app.check_notes && (
+                      <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+                        Notes: {app.check_notes}
+                      </Typography>
+                    )}
+
+                    {app.specializations?.length > 0 && (
+                      <Box display="flex" gap={0.5} flexWrap="wrap" mt={1}>
+                        {app.specializations.map(s => (
+                          <Chip key={s.id} label={s.name} size="small" variant="outlined" />
+                        ))}
+                      </Box>
+                    )}
+                  </Box>
+
+                  <Box display="flex" flexDirection="column" gap={1} flexShrink={0}>
+                    <Button
+                      variant="contained" size="small" startIcon={<CheckCircle />}
+                      onClick={() => handleApprove(app.id)}
+                      sx={{ bgcolor: '#7B2FBE', '&:hover': { bgcolor: '#6a27a3' } }}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      variant="outlined" size="small" startIcon={<Cancel />}
+                      onClick={() => handleReject(app.id)}
+                      color="error"
+                    >
+                      Reject
+                    </Button>
+                  </Box>
+                </Box>
+              </Paper>
+            ))
+          )}
+        </>
+      )}
+
+      {tab === 1 && (
+        <Paper sx={{ borderRadius: 3, overflow: 'hidden' }}>
+          {appointments.length === 0 ? (
+            <Box p={4} textAlign="center">
+              <CalendarMonth sx={{ fontSize: 48, color: '#d0b0f0', mb: 1 }} />
+              <Typography color="text.secondary">No appointments found.</Typography>
+            </Box>
+          ) : (
+            <Table size="small">
+              <TableHead>
+                <TableRow sx={{ bgcolor: '#f3e8ff' }}>
+                  <TableCell sx={{ fontWeight: 600 }}>Date</TableCell>
+                  <TableCell>Client</TableCell>
+                  <TableCell>Support Worker</TableCell>
+                  <TableCell>Location</TableCell>
+                  <TableCell>Duration</TableCell>
+                  <TableCell>Status</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {appointments.map(appt => (
+                  <TableRow key={appt.id} hover>
+                    <TableCell>
+                      {new Date(appt.date).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })}
+                    </TableCell>
+                    <TableCell>{appt.client ? `${appt.client.first_name} ${appt.client.last_name}` : '—'}</TableCell>
+                    <TableCell>{appt.support_worker ? `${appt.support_worker.first_name} ${appt.support_worker.last_name}` : '—'}</TableCell>
+                    <TableCell>{appt.location || '—'}</TableCell>
+                    <TableCell>{appt.duration ? `${appt.duration} min` : '—'}</TableCell>
+                    <TableCell>
+                      <Chip
+                        label={appt.status}
+                        size="small"
+                        sx={{
+                          bgcolor: appt.status === 'approved' ? '#e8f5e9' : appt.status === 'pending' ? '#f3e8ff' : '#fce4e4',
+                          color: appt.status === 'approved' ? '#2e7d32' : appt.status === 'pending' ? '#7B2FBE' : '#c62828',
+                        }}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </Paper>
+      )}
+    </Box>
+  );
+};
+
+export default AdminDashboard;

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -18,7 +18,13 @@ const Login = () => {
       auth.setUser(response.data.user);
       auth.setClient(response.data.client);
       auth.setSupportWorker(response.data.support_worker);
-      navigate('/');
+      if (response.data.user?.is_admin) {
+        navigate('/admin');
+      } else if (response.data.support_worker?.status === 'pending') {
+        navigate('/vetting');
+      } else {
+        navigate('/');
+      }
     } catch (error) {
       setError('Invalid email or password');
     }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -32,26 +32,35 @@ const Navbar = () => {
     navigate('/login');
   };
 
+  const isAdmin = auth.user?.is_admin;
+  const isPendingWorker = auth.supportWorker?.status === 'pending';
+
+
   return (
     <AppBar sx={{ backgroundColor: '#7B2FBE', boxShadow: 'none' }}>
       <Toolbar>
         <Button color="inherit" component={Link} to="/">Home</Button>
-        {auth.supportWorker && <Button color="inherit" component={Link} to="/clients">Clients</Button>}
-        <Button color="inherit" component={Link} to="/support-workers">Support Workers</Button>
-        <Button color="inherit" component={Link} to="/appointments">Appointments</Button>
-        {(auth.client || auth.supportWorker) && (
-          <Button color="inherit" component={Link} to="/messages" onClick={() => setUnreadMessages(0)}>
-            <Badge badgeContent={unreadMessages} color="error" max={9}>
-              Messages
-            </Badge>
-          </Button>
-        )}
-        {(auth.client || auth.supportWorker) && (
-          <Button color="inherit" component={Link} to="/invitations" onClick={() => setInvitationsBadge(0)}>
-            <Badge badgeContent={invitationsBadge} color="error" max={9}>
-              Invitations
-            </Badge>
-          </Button>
+        {isAdmin && <Button color="inherit" component={Link} to="/admin">Admin</Button>}
+        {!isAdmin && !isPendingWorker && (
+          <>
+            {auth.supportWorker && <Button color="inherit" component={Link} to="/clients">Clients</Button>}
+            <Button color="inherit" component={Link} to="/support-workers">Support Workers</Button>
+            <Button color="inherit" component={Link} to="/appointments">Appointments</Button>
+            {(auth.client || auth.supportWorker) && (
+              <Button color="inherit" component={Link} to="/messages" onClick={() => setUnreadMessages(0)}>
+                <Badge badgeContent={unreadMessages} color="error" max={9}>
+                  Messages
+                </Badge>
+              </Button>
+            )}
+            {(auth.client || auth.supportWorker) && (
+              <Button color="inherit" component={Link} to="/invitations" onClick={() => setInvitationsBadge(0)}>
+                <Badge badgeContent={invitationsBadge} color="error" max={9}>
+                  Invitations
+                </Badge>
+              </Button>
+            )}
+          </>
         )}
 
         <Box sx={{ flexGrow: 1 }} />
@@ -64,9 +73,9 @@ const Navbar = () => {
                 else if (auth.supportWorker) navigate(`/support-workers/${auth.supportWorker!.id}`);
               }}
             >
-              Welcome, {auth.user.first_name}
+              Welcome, {auth.user.first_name ?? auth.user.email}
             </Typography>
-            {(auth.client || auth.supportWorker) && (
+            {(auth.client || auth.supportWorker) && !isPendingWorker && (
               <Tooltip title="My Profile">
                 <IconButton
                   onClick={() => auth.client

--- a/src/components/SecureRoute.test.tsx
+++ b/src/components/SecureRoute.test.tsx
@@ -32,4 +32,24 @@ describe('SecureRoute', () => {
     render(<SecureRoute><div>Protected</div></SecureRoute>);
     expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/login');
   });
+
+  it('redirects to /vetting when support worker status is pending', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      user: { id: 1, email: 'sw@test.com' },
+      supportWorker: { status: 'pending' },
+    });
+    render(<SecureRoute><div>Protected</div></SecureRoute>);
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/vetting');
+  });
+
+  it('renders children when support worker is approved', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      user: { id: 1, email: 'sw@test.com' },
+      supportWorker: { status: 'approved' },
+    });
+    render(<SecureRoute><div>Protected</div></SecureRoute>);
+    expect(screen.getByText('Protected')).toBeInTheDocument();
+  });
 });

--- a/src/components/SecureRoute.tsx
+++ b/src/components/SecureRoute.tsx
@@ -6,13 +6,10 @@ interface SecureRouteProps {
 }
 const SecureRoute = ({ children }: SecureRouteProps) => {
   const auth = useAuth()
-  if (auth.loading ) {
-    return null
-  } else if (auth?.user) {
-    return children;
-  } else {
-    return <Navigate to="/login" />
-  }
+  if (auth.loading) return null;
+  if (!auth.user) return <Navigate to="/login" />;
+  if (auth.supportWorker?.status === 'pending') return <Navigate to="/vetting" />;
+  return children;
 };
 
 export default SecureRoute;;

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -79,7 +79,12 @@ const SignUp = () => {
       auth.setUser(loginResponse.data.user);
       auth.setClient(loginResponse.data.client);
       auth.setSupportWorker(loginResponse.data.support_worker);
-      navigate('/');
+      const sw = loginResponse.data.support_worker;
+      if (sw && sw.status === 'pending') {
+        navigate('/vetting');
+      } else {
+        navigate('/');
+      }
     } catch (err: any) {
       const errorData = err.response?.data?.errors || err.response?.data?.error;
       setErrors(Array.isArray(errorData) ? errorData : [errorData || 'An error occurred']);

--- a/src/components/VettingAgent.test.tsx
+++ b/src/components/VettingAgent.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VettingAgent from './VettingAgent';
+import { useAuth } from '../context/AuthContext';
+import axiosInstance from '../api/axiosConfig';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('../context/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../api/axiosConfig', () => ({
+  post: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockAxiosPost = axiosInstance.post as jest.Mock;
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('VettingAgent', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      supportWorker: { first_name: 'Alex', status: 'pending' },
+    });
+  });
+
+  it('renders the compliance vetting header', () => {
+    render(<VettingAgent />);
+    expect(screen.getByText('Compliance Vetting')).toBeInTheDocument();
+  });
+
+  it('opens with a greeting that asks for the police check number', () => {
+    render(<VettingAgent />);
+    expect(screen.getByText(/Police Check reference number/i)).toBeInTheDocument();
+  });
+
+  it('sends user message and displays reply', async () => {
+    mockAxiosPost.mockResolvedValueOnce({
+      data: { reply: 'Thanks! Now your WWCC number.', complete: false },
+    });
+    render(<VettingAgent />);
+
+    const input = screen.getByPlaceholderText(/Type your response/i);
+    await userEvent.type(input, 'ABC123456');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByText('ABC123456')).toBeInTheDocument();
+      expect(screen.getByText('Thanks! Now your WWCC number.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows completion state and hides input when vetting is complete', async () => {
+    mockAxiosPost.mockResolvedValueOnce({
+      data: { reply: 'All done!', complete: true, recommendation: 'approved' },
+    });
+    render(<VettingAgent />);
+
+    const input = screen.getByPlaceholderText(/Type your response/i);
+    await userEvent.type(input, 'WWC7654321');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByText(/details have been submitted and look great/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /go to dashboard/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByPlaceholderText(/Type your response/i)).not.toBeInTheDocument();
+  });
+
+  it('shows needs_review message when recommendation is needs_review', async () => {
+    mockAxiosPost.mockResolvedValueOnce({
+      data: { reply: 'Submitted.', complete: true, recommendation: 'needs_review' },
+    });
+    render(<VettingAgent />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Type your response/i), 'abc');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByText(/submitted for manual review/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/VettingAgent.tsx
+++ b/src/components/VettingAgent.tsx
@@ -19,7 +19,7 @@ const VettingAgent = () => {
   const [messages, setMessages] = useState<Message[]>([
     {
       role: 'assistant',
-      content: `Hi ${supportWorker?.first_name ?? 'there'}! Welcome to the vetting process. Before you can be listed on the platform, I need to collect a few details for compliance. This won't take long — I'll walk you through it step by step.`,
+      content: `Hi ${supportWorker?.first_name ?? 'there'}! Welcome to the vetting process. Before you can be listed on the platform, I need to collect two compliance check numbers — your Police Check and your Working With Children Check (WWCC).\n\nLet's start: what is your Police Check reference number?`,
     },
   ]);
   const [input, setInput] = useState('');

--- a/src/components/VettingAgent.tsx
+++ b/src/components/VettingAgent.tsx
@@ -1,0 +1,137 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box, Typography, Paper, TextField, IconButton, CircularProgress,
+  Alert, Button,
+} from '@mui/material';
+import { Send, CheckCircle, AdminPanelSettings } from '@mui/icons-material';
+import axiosInstance from '../api/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const VettingAgent = () => {
+  const { supportWorker } = useAuth();
+  const navigate = useNavigate();
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      role: 'assistant',
+      content: `Hi ${supportWorker?.first_name ?? 'there'}! Welcome to the vetting process. Before you can be listed on the platform, I need to collect a few details for compliance. This won't take long — I'll walk you through it step by step.`,
+    },
+  ]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [complete, setComplete] = useState(false);
+  const [recommendation, setRecommendation] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || loading) return;
+    const next: Message[] = [...messages, { role: 'user', content: text }];
+    setMessages(next);
+    setInput('');
+    setLoading(true);
+    try {
+      const { data } = await axiosInstance.post('/vetting/chat', {
+        message: text,
+        history: messages,
+      });
+      setMessages([...next, { role: 'assistant', content: data.reply }]);
+      if (data.complete) {
+        setComplete(true);
+        setRecommendation(data.recommendation);
+      }
+    } catch {
+      setMessages([...next, { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box maxWidth={680} mx="auto" mt={5} px={2} display="flex" flexDirection="column" height="calc(100vh - 140px)">
+      <Paper sx={{ p: 2.5, borderRadius: 3, mb: 2, display: 'flex', alignItems: 'center', gap: 2, bgcolor: '#f3e8ff' }}>
+        <AdminPanelSettings sx={{ color: '#7B2FBE', fontSize: 32 }} />
+        <Box>
+          <Typography variant="h6" fontWeight={700} color="#7B2FBE">Compliance Vetting</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Complete your police check and WWCC verification to be listed on the platform.
+          </Typography>
+        </Box>
+      </Paper>
+
+      {complete && (
+        <Alert
+          severity={recommendation === 'approved' ? 'success' : 'info'}
+          icon={<CheckCircle />}
+          sx={{ mb: 2, borderRadius: 2 }}
+        >
+          {recommendation === 'approved'
+            ? 'Your details have been submitted and look great! An admin will review and approve your profile shortly.'
+            : 'Your details have been submitted for manual review. An admin will be in touch.'}
+        </Alert>
+      )}
+
+      <Paper sx={{ flex: 1, overflowY: 'auto', p: 2, borderRadius: 3, mb: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {messages.map((msg, i) => (
+          <Box key={i} display="flex" justifyContent={msg.role === 'user' ? 'flex-end' : 'flex-start'}>
+            <Box sx={{
+              maxWidth: '75%',
+              p: 1.5,
+              borderRadius: msg.role === 'user' ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
+              bgcolor: msg.role === 'user' ? '#7B2FBE' : '#f3e8ff',
+              color: msg.role === 'user' ? 'white' : 'text.primary',
+            }}>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>{msg.content}</Typography>
+            </Box>
+          </Box>
+        ))}
+        {loading && (
+          <Box display="flex" justifyContent="flex-start" pl={0.5}>
+            <Box sx={{ bgcolor: '#f3e8ff', borderRadius: '16px 16px 16px 4px', px: 1.5, py: 1 }}>
+              <CircularProgress size={14} sx={{ color: '#7B2FBE' }} />
+            </Box>
+          </Box>
+        )}
+        <div ref={bottomRef} />
+      </Paper>
+
+      {complete ? (
+        <Paper sx={{ p: 2, borderRadius: 3, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary" mb={1.5}>
+            You're all done! We'll notify you once your profile is approved.
+          </Typography>
+          <Button
+            variant="outlined"
+            onClick={() => navigate('/')}
+            sx={{ borderColor: '#7B2FBE', color: '#7B2FBE' }}
+          >
+            Go to Dashboard
+          </Button>
+        </Paper>
+      ) : (
+        <Paper sx={{ p: 1.5, borderRadius: 3, display: 'flex', gap: 1, alignItems: 'flex-end' }}>
+          <TextField
+            fullWidth size="small" placeholder="Type your response…"
+            value={input} onChange={e => setInput(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); } }}
+            multiline maxRows={3} disabled={loading}
+          />
+          <IconButton onClick={sendMessage} disabled={!input.trim() || loading} sx={{ color: '#7B2FBE', mb: 0.25 }}>
+            <Send />
+          </IconButton>
+        </Paper>
+      )}
+    </Box>
+  );
+};
+
+export default VettingAgent;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -9,6 +9,7 @@ interface User {
   middle_name: string | null;
   email: string;
   role: string | null;
+  is_admin: boolean;
 }
 
 export interface Client {
@@ -52,6 +53,7 @@ export interface SupportWorker {
   emergency_contact_last_name: string;
   emergency_contact_phone: string;
   specializations?: Specialization[];
+  status?: string;
 }
 
 interface AuthProviderProps {


### PR DESCRIPTION
## Summary
- **Admin role**: `is_admin` flag on User — admins get their own dashboard and bypass normal nav
- **Vetting flow**: New support workers land on `/vetting` after sign-up/login — an AI agent (Claude Haiku) collects their Police Check number and WWCC number, simulates verification, and flags for admin review
- **Admin dashboard**: `/admin` — two tabs: Pending Applications (with agent recommendation chip, approve/reject) and All Appointments (full table view)
- **Pending workers hidden**: Only `approved` workers appear in client-facing lists; pending/rejected are invisible until approved

## Test accounts
| Role | Email | Password |
|------|-------|----------|
| Admin | admin@supportapp.com | admin123 |
| Pending worker | pending.worker@example.com | password123 |

## Test plan
- [ ] Sign up as a new support worker → lands on `/vetting`
- [ ] Complete vetting chat (provide two reference numbers) → sees completion message
- [ ] Log in as admin → lands on `/admin`, sees pending application with agent recommendation
- [ ] Approve application → worker disappears from pending list
- [ ] Log in as approved worker (e.g. olivia.williams@example.com) → normal flow, appears in client searches
- [ ] Log in as pending worker → only sees vetting page, not support worker lists
- [ ] All Appointments tab shows full appointment history

🤖 Generated with [Claude Code](https://claude.com/claude-code)